### PR TITLE
Corrigido bug em order_data()

### DIFF
--- a/woocommerce_nfe.php
+++ b/woocommerce_nfe.php
@@ -422,7 +422,7 @@ class WooCommerceNFe {
                     
                     $data['produtos'][] = array(
                         'nome' => $item['name'], // Nome do produto
-                        'sku' => $product->get_sku(), // Código identificador - SKU
+                        'sku' => ''), // Código identificador - SKU
                         'ean' => $codigo_ean, // Código EAN
                         'ncm' => $codigo_ncm, // Código NCM
                         'cest' => $codigo_cest, // Código CEST

--- a/woocommerce_nfe.php
+++ b/woocommerce_nfe.php
@@ -422,7 +422,7 @@ class WooCommerceNFe {
                     
                     $data['produtos'][] = array(
                         'nome' => $item['name'], // Nome do produto
-                        'sku' => ''), // Código identificador - SKU
+                        'sku' => '', // Código identificador - SKU
                         'ean' => $codigo_ean, // Código EAN
                         'ncm' => $codigo_ncm, // Código NCM
                         'cest' => $codigo_cest, // Código CEST


### PR DESCRIPTION
Removido a função $product->get_sku() no loop de fees do pedido. As fees não possuem essa função, e ao tentar tratá-las como produto, o woocomerce não disponibiliza as mesmas funções.
