### PR TITLE
attempt at adding broader support for different bundle style products

### DIFF
--- a/inc/compatibility.php
+++ b/inc/compatibility.php
@@ -1,0 +1,141 @@
+<?php
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Compatibility with other extensions.
+ *
+ * @class    WC_NFe_Compatibility
+ * @version  2.2.0
+ */
+class WC_NFe_Compatibility {
+
+	/**
+	 * Complex product types integrated with SATT.
+	 * @var array
+	 */
+	private static $bundle_types = array();
+
+	/**
+	 * Complex type container cart/order item key names.
+	 *
+	 * @deprecated  2.8.0
+	 * @var         array
+	 */
+	public static $container_key_names = array();
+
+	/**
+	 * Complex type child cart/order item key names.
+	 *
+	 * @deprecated  2.8.0
+	 * @var         array
+	 */
+	public static $child_key_names = array();
+
+	/**
+	 * Initialize.
+	 */
+	public static function init() {
+
+		// Bundles.
+		if ( class_exists( 'Yith_Bundles' ) ) {
+			self::$bundle_types[]                      = 'yith_bundle';
+			self::$container_key_names[]               = 'bundled_by';
+			self::$child_key_names[]                   = 'bundled_items';
+		}
+
+		// Bundles.
+		if ( class_exists( 'WC_Bundles' ) ) {
+			self::$bundle_types[]                      = 'bundle';
+			self::$container_key_names[]               = 'bundled_by';
+			self::$child_key_names[]                   = 'bundled_items';
+		}
+
+		// Composites.
+		if ( class_exists( 'WC_Composite_Products' ) ) {
+			self::$bundle_types[]                      = 'composite';
+			self::$container_key_names[]               = 'composite_parent';
+			self::$child_key_names[]                   = 'composite_children';
+		}
+
+		// Mix n Match.
+		if ( class_exists( 'WC_Mix_and_Match' ) ) {
+			self::$bundle_types[]                      = 'mix-and-match';
+			self::$container_key_names[]               = 'mnm_container';
+			self::$child_key_names[]                   = 'mnm_contents';
+		}
+
+	}
+
+	/*
+	|--------------------------------------------------------------------------
+	| Helpers
+	|--------------------------------------------------------------------------
+	*/
+
+	/**
+	 * Checks if the passed product is of a supported bundle type. Returns the type if yes, or false if not.
+	 *
+	 * @param  WC_Product  $product
+	 * @return boolean
+	 */
+	public static function is_bundle_type_product( $product ) {
+		return $product->is_type( self::$bundle_types );
+	}
+
+
+
+	/**
+	 * True if an order item appears to be a bundle-type container item.
+	 *
+	 * @since  2.8.0
+	 *
+	 * @param  array     $order_item
+	 * @return boolean
+	 */
+	public static function maybe_is_bundle_type_container_order_item( $order_item ) {
+
+		$is = false;
+
+		foreach ( self::$container_order_item_conditionals as $container_order_item_conditional ) {
+			$is = ! empty( $order_item[ $container_order_item_conditional ] );
+
+			if ( $is ) {
+				break;
+			}
+		}
+
+		return $is;
+	}
+
+	/**
+	 * True if an order item appears to be part of a bundle-type product.
+	 *
+	 * @since  2.8.0
+	 *
+	 * @param  array     $cart_item
+	 * @return boolean
+	 */
+	public static function maybe_is_bundled_type_order_item( $order_item ) {
+
+		$is = false;
+
+		foreach ( self::$container_key_names as $container_key_name ) {
+			$is = ! empty( $order_item[ $container_key_name ] );
+
+			if ( $is ) {
+				break;
+			}
+		}
+
+		return $is;
+	}
+
+
+}
+
+
+WC_NFe_Compatibility::init();

--- a/woocommerce_nfe.php
+++ b/woocommerce_nfe.php
@@ -158,6 +158,7 @@ class WooCommerceNFe {
 		include_once( 'inc/custom_frontend.php' );
 		include_once( 'inc/format.php' );
 		include_once( 'inc/api.php' );
+		include_once( 'inc/compatibility.php' );
 	}
 	function init_hooks(){
 		// WooCommerceNFe
@@ -440,16 +441,12 @@ class WooCommerceNFe {
 			$product_type = $product->get_type();
 			$product_id   = $item['product_id'];
 
-			$bundled_by = isset($item['bundled_by']);
-			if(!$bundled_by && is_a($item, 'WC_Order_Item_Product')){
-				$bundled_by = $item->meta_exists('_bundled_by');
-			}
-
-			$variation_id = $item['variation_id'];
-			if( $product_type == 'bundle' || $product_type == 'yith_bundle' || $bundled_by ){
+			if( WC_NFe_Compatibility::is_bundle_type_product( $product) || WC_NFe_Compatibility::is_bundle_type_order_item( $item ) ) {
 				$bundles[] = $item;
 				continue;
 			}
+
+			$variation_id = $item['variation_id'];
 
 			$product_info = self::get_product_nfe_info($item, $order);
 
@@ -628,15 +625,9 @@ class WooCommerceNFe {
 			$product_type = $product->get_type();
 			$product_price = $product->get_price();
 
-
-			$bundled_by = isset($item['bundled_by']);
-			if(!$bundled_by && is_a($item, 'WC_Order_Item_Product')){
-				$bundled_by = $item->meta_exists('_bundled_by');
-			}
-
-
-
-			if($bundled_by){
+			if( WC_NFe_Compatibility::is_bundle_type_product( $product ) ){
+				$total_bundle += $product_price*$item['qty'];
+			}else{
 				$product_total = $product_price * $item['qty'];
 				$total_products += $product_total;
 				if(!isset($bundle_products[$item['product_id']])){
@@ -649,8 +640,6 @@ class WooCommerceNFe {
 					$bundle_products[$item['product_id']]['quantidade'] = $new_qty;
 					$bundle_products[$item['product_id']]['total'] = number_format($new_total, 2, '.', '' );
 				}
-			}elseif($product_type == 'yith_bundle'){
-				$total_bundle += $product_price*$item['qty'];
 			}
 		}
 		if($total_products < $total_bundle){


### PR DESCRIPTION
Following up to Support ticket 17477.

>The problem is, it's not working for mix and match products, because in the order we have a parent product (the mix and match) with the price, and all child products with a price of 0. The government system don't accept a product with a price of 0 in their system. 

I noticed that you have explicit compatibility code for Yith Product Bundles so I've tried to extend that to
Mix and Match, Product Bundles, and Composite products. Those 3 plugins all have conditional functions such as `wc_pb_is_bundled_order_item()` to test whether the item is a bundled item, but I'm not sure about Yith so I've tried to preserve your current system as much as possible.

I can't really test this without API keys for the Brazilian system. So this is only theoretical at this point.

CC: @franticpsyx