### PR TITLE
Adicionar o bacs.php

### DIFF
--- a/init-class.php
+++ b/init-class.php
@@ -150,6 +150,7 @@ class WooCommerceNFe {
 		include_once( 'inc/gateways/pagarme.php' );
 		include_once( 'inc/gateways/pagseguro.php' );
 		include_once( 'inc/gateways/paypal.php' );
+		include_once( 'inc/gateways/bacs.php' );		
 		include_once( 'class-format.php' );
 		include_once( 'class-issue.php' );
 		include_once( 'class-backend.php' );


### PR DESCRIPTION
Na última atualização, o bacs.php não foi incluído no código, gerando o erro:

Uncaught Error: Class 'NFeGatewayBacs' not found in /home/u358809076/domains/useupacessorios.com.br/public_html/wp-content/plugins/nota-fiscal-eletronica-woocommerce/inc/gateways/utils.php:29

Esse include resolve o problema.