### PR TITLE
Atualizar a função get_gateway_class para static

### DIFF
--- a/inc/gateways/utils.php
+++ b/inc/gateways/utils.php
@@ -8,7 +8,7 @@ class UtilsGateways {
    * @param string $payment_method
    * @return string [Gateway name]
    */
-  function get_gateway_class( $payment_method ){
+  static function get_gateway_class( $payment_method ){
 
     if (in_array( $payment_method, NFeGatewayEbanx::payment_methods() )){
 


### PR DESCRIPTION
O único lugar em que a função é chamada é na classe WooCommerceNFeIssue (class-issue.php) na linha 152 e para a chamada funcionar, a função precisa ser declarada como static.

Por causa disso eu estava obtendo o seguinte erro:
Uncaught Error: Non-static method UtilsGateways::get_gateway_class() cannot be called statically
in wp-content\plugins\nota-fiscal-eletronica-woocommerce\class-issue.php on line 152