### PR TITLE
Corrige emissão automática de NF

### DIFF
--- a/init-class.php
+++ b/init-class.php
@@ -49,7 +49,7 @@ class WooCommerceNFe {
 	function hooks(){
 
 		add_filter( 'woocommercenfe_plugins_url', array($this, 'default_plugin_url') );
-		add_action( 'transition_post_status', array($this, 'issue_automatic_invoice'), 10, 4 );
+		add_action( 'woocommerce_order_status_changed', array($this, 'issue_automatic_invoice'), 10, 4 );
 		add_filter( "plugin_action_links_".plugin_basename( __FILE__ ), array($this, 'plugin_add_settings_link') );
 		do_action( 'woocommercenfe_loaded' );
 
@@ -258,28 +258,21 @@ class WooCommerceNFe {
 	 *
 	 * @return void
 	 */
-	function issue_automatic_invoice( $to, $from, $post ) {
-		
-		// Validations
-		if (get_post_type($post) != 'shop_order')
-			return;
+	function issue_automatic_invoice( $order_id, $from, $to, $order ) {
 
 		$option = apply_filters( 'nfe_issue_automatic', get_option('wc_settings_woocommercenfe_emissao_automatica') );
 		if ( !$option ){
 			return;
 		}
 
-		// Vars
-		$order_id = $post->ID;
-		$order = wc_get_order( $order_id );
+		$response = null;
 
 		// Process
 		if (
-			$to == 'wc-processing' && ($option == 1 || $option == 'yes') ||
-			$to == 'wc-completed' && $option == 2
+			$to == 'processing' && ($option == 1 || $option == 'yes') ||
+			$to == 'completed' && $option == 2
 		){
-			
-			$nfes = get_post_meta( $order->id,  'nfe', true );
+			$nfes = $order->get_meta( 'nfe', true );
 
 			if ( !empty($nfes) && is_array($nfes) ) {
 				foreach ( $nfes as $nfe ) {


### PR DESCRIPTION
Estou tendo problemas com a emissão automática de NF no WooCommerce 9.0.1 (HPOS ativado e modo compatibilidade desativado).

Fiz alguns testes e parece que o hook transition_post_status não é executado quando ocorre a mudança de status. Não tenho certeza se pode ser algo exclusivo do meu setup. 
Tentei alterar para o hook woocommerce_order_status_changed, fazendo as devidas modificações no código, e aí deu certo.
