### PR TITLE
Sync public plugin with official master — security hardening + PHP 8 fixes (3.4.0.3 → 3.4.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Através do emissor de Nota Fiscal da Webmania®, você conta com a emissão e a
 
 ## Requisitos
 
-- Contrate um dos planos de Nota Fiscal da Webmania®: [Assine agora mesmo](https://webmaniabr.com/nota-fiscal-eletronica/#plans-section).
+- Contrate um dos planos de Nota Fiscal da Webmania® (Teste 30 dias grátis): [Assine agora mesmo](https://webmaniabr.com/nota-fiscal-eletronica/).
 - Instale o módulo grátis do WooCommerce da Webmania® e configure conforme instruções.
 
 ## Instalação do Módulo

--- a/assets/js/admin_scripts.js
+++ b/assets/js/admin_scripts.js
@@ -1,9 +1,38 @@
 jQuery( function ( $ ) {
 
+    // Security: Escape HTML function
+    function escapeHtml(text) {
+        var map = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#039;'
+        };
+        return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+    }
+
+    // Security: Validate input function
+    function validateInput(value, type) {
+        if (type === 'number') {
+            return !isNaN(value) && isFinite(value);
+        }
+        if (type === 'email') {
+            var re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            return re.test(value);
+        }
+        return true;
+    }
+
     load_billing = function(){
 
+        var userId = parseInt($( '#customer_user' ).val(), 10);
+        if (!userId || userId < 1) {
+            return;
+        }
+
         data = {
-            user_id:      $( '#customer_user' ).val(),
+            user_id:      userId,
             type_to_load: 'billing',
             action:       'woocommerce_get_customer_details',
             security:     woocommerce_admin_meta_boxes.get_customer_details_nonce
@@ -16,25 +45,26 @@ jQuery( function ( $ ) {
             success: function( response ) {
                 var info = response;
                 if ( info ) {
-                    $( '#_billing_persontype' ).val( info.billing_persontype ).change();
-                    $( 'input#_billing_cpf' ).val( info.billing_cpf ).change();
-                    $( 'input#_billing_cnpj' ).val( info.billing_cnpj ).change();
-                    $( 'input#_billing_ie' ).val( info.billing_ie ).change();
+                    // Security: Sanitize all values before setting
+                    $( '#_billing_persontype' ).val( escapeHtml(info.billing_persontype || '') ).change();
+                    $( 'input#_billing_cpf' ).val( escapeHtml(info.billing_cpf || '') ).change();
+                    $( 'input#_billing_cnpj' ).val( escapeHtml(info.billing_cnpj || '') ).change();
+                    $( 'input#_billing_ie' ).val( escapeHtml(info.billing_ie || '') ).change();
                     $( 'input#_billing_birthdate' ).val( '' ).change();
                     $( 'input#_billing_sex' ).val( '' ).change();
-                    $( 'input#_billing_number' ).val( info.billing_number ).change();
-                    $( 'input#_billing_neighborhood' ).val( info.billing_neighborhood ).change();
-                    $( 'input#_billing_address_1' ).val( info.billing_address_1 ).change();
-                    $( 'input#_billing_address_2' ).val( info.billing_address_2 ).change();
-                    $( 'input#_billing_first_name' ).val( info.billing_first_name ).change();
-                    $( 'input#_billing_last_name' ).val( info.billing_last_name ).change();
-                    $( 'input#_billing_city' ).val( info.billing_city ).change();
-                    $( 'input#_billing_postcode' ).val( info.billing_postcode ).change();
-                    $( '#_billing_country' ).val( info.billing_country ).change();
-                    $( '#_billing_state' ).val( info.billing_state ).change();
-                    $( 'input#_billing_email' ).val( info.billing_email ).change();
-                    $( 'input#_billing_phone' ).val( info.billing_phone ).change();
-                    $( 'input#_billing_company' ).val( info.billing_company ).change();
+                    $( 'input#_billing_number' ).val( escapeHtml(info.billing_number || '') ).change();
+                    $( 'input#_billing_neighborhood' ).val( escapeHtml(info.billing_neighborhood || '') ).change();
+                    $( 'input#_billing_address_1' ).val( escapeHtml(info.billing_address_1 || '') ).change();
+                    $( 'input#_billing_address_2' ).val( escapeHtml(info.billing_address_2 || '') ).change();
+                    $( 'input#_billing_first_name' ).val( escapeHtml(info.billing_first_name || '') ).change();
+                    $( 'input#_billing_last_name' ).val( escapeHtml(info.billing_last_name || '') ).change();
+                    $( 'input#_billing_city' ).val( escapeHtml(info.billing_city || '') ).change();
+                    $( 'input#_billing_postcode' ).val( escapeHtml(info.billing_postcode || '') ).change();
+                    $( '#_billing_country' ).val( escapeHtml(info.billing_country || '') ).change();
+                    $( '#_billing_state' ).val( escapeHtml(info.billing_state || '') ).change();
+                    $( 'input#_billing_email' ).val( escapeHtml(info.billing_email || '') ).change();
+                    $( 'input#_billing_phone' ).val( escapeHtml(info.billing_phone || '') ).change();
+                    $( 'input#_billing_company' ).val( escapeHtml(info.billing_company || '') ).change();
                 }
             }
         });
@@ -43,8 +73,13 @@ jQuery( function ( $ ) {
 
     load_shipping = function(){
 
+        var userId = parseInt($( '#customer_user' ).val(), 10);
+        if (!userId || userId < 1) {
+            return;
+        }
+
         data = {
-            user_id:      $( '#customer_user' ).val(),
+            user_id:      userId,
             type_to_load: 'shipping',
             action:       'woocommerce_get_customer_details',
             security:     woocommerce_admin_meta_boxes.get_customer_details_nonce
@@ -57,17 +92,18 @@ jQuery( function ( $ ) {
             success: function( response ) {
                 var info = response;
                 if ( info ) {
-                    $( 'input#_shipping_number' ).val( info.shipping_number ).change();
-                    $( 'input#_shipping_neighborhood' ).val( info.shipping_neighborhood ).change();
-                    $( 'input#_shipping_first_name' ).val( info.shipping_first_name ).change();
-                    $( 'input#_shipping_last_name' ).val( info.shipping_last_name ).change();
-                    $( 'input#_shipping_company' ).val( info.shipping_company ).change();
-                    $( 'input#_shipping_address_1' ).val( info.shipping_address_1 ).change();
-                    $( 'input#_shipping_address_2' ).val( info.shipping_address_2 ).change();
-                    $( 'input#_shipping_city' ).val( info.shipping_city ).change();
-                    $( 'input#_shipping_postcode' ).val( info.shipping_postcode ).change();
-                    $( '#_shipping_country' ).val( info.shipping_country ).change();
-                    $( '#_shipping_state' ).val( info.shipping_state ).change();
+                    // Security: Sanitize all values before setting
+                    $( 'input#_shipping_number' ).val( escapeHtml(info.shipping_number || '') ).change();
+                    $( 'input#_shipping_neighborhood' ).val( escapeHtml(info.shipping_neighborhood || '') ).change();
+                    $( 'input#_shipping_first_name' ).val( escapeHtml(info.shipping_first_name || '') ).change();
+                    $( 'input#_shipping_last_name' ).val( escapeHtml(info.shipping_last_name || '') ).change();
+                    $( 'input#_shipping_company' ).val( escapeHtml(info.shipping_company || '') ).change();
+                    $( 'input#_shipping_address_1' ).val( escapeHtml(info.shipping_address_1 || '') ).change();
+                    $( 'input#_shipping_address_2' ).val( escapeHtml(info.shipping_address_2 || '') ).change();
+                    $( 'input#_shipping_city' ).val( escapeHtml(info.shipping_city || '') ).change();
+                    $( 'input#_shipping_postcode' ).val( escapeHtml(info.shipping_postcode || '') ).change();
+                    $( '#_shipping_country' ).val( escapeHtml(info.shipping_country || '') ).change();
+                    $( '#_shipping_state' ).val( escapeHtml(info.shipping_state || '') ).change();
                 }
 
             }
@@ -223,8 +259,10 @@ jQuery( function ( $ ) {
     format_field_tax_class = function(element) {
 
       var new_value;
+      var inputValue = element.target.value || '';
 
-      new_value = 'REF' + element.target.value.replace(/\D|[REF]/g, '');
+      // Security: Sanitize input
+      new_value = 'REF' + inputValue.replace(/[^0-9]/g, '');
     
       $(element.target).val(new_value);
 
@@ -266,9 +304,13 @@ jQuery( function ( $ ) {
     });
     $('input[name="nfe_installments_n"]').on('change', function(){
 
-      value = $(this).val();
-      div = $('.nfe_installments.row-first');
-      total = $('.nfe_installments.row').length + 1;
+      // Security: Validate and limit input
+      var value = parseInt($(this).val(), 10);
+      if (isNaN(value) || value < 0 || value > 100) {
+          return;
+      }
+      var div = $('.nfe_installments.row-first');
+      var total = $('.nfe_installments.row').length + 1;
 
       if (value > total){
 

--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -28,10 +28,13 @@ jQuery(function($){
     }
 
     if (WooCommerceNFe.cep) {
-
-        correios.init( 'qS4SKlmAXR21h7wrBMcs0SZyXauLqo5m', 'nkKkInYJ5QvogYn1xj4lk7w3hkhA8qzruoKzuLf6UyBtSIJL' );
-        $('#billing_postcode').correios( '#billing_address_1', '#billing_neighborhood', '#billing_city', '#billing_state', '#loading', false );
-        $('#shipping_postcode').correios( '#shipping_address_1', '#shipping_neighborhood', '#shipping_city', '#shipping_state', '#loading', false );
+        
+        // Security: Use configuration from PHP instead of hardcoded credentials
+        if (typeof WooCommerceNFe.correios_key !== 'undefined' && typeof WooCommerceNFe.correios_secret !== 'undefined') {
+            correios.init( WooCommerceNFe.correios_key, WooCommerceNFe.correios_secret );
+            $('#billing_postcode').correios( '#billing_address_1', '#billing_neighborhood', '#billing_city', '#billing_state', '#loading', false );
+            $('#shipping_postcode').correios( '#shipping_address_1', '#shipping_neighborhood', '#shipping_city', '#shipping_state', '#loading', false );
+        }
 
     }
 

--- a/class-backend.php
+++ b/class-backend.php
@@ -6,10 +6,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WooCommerceNFeBackend extends WooCommerceNFe {
 
+	private $auto_invoice_notice = null;
+
 	function __construct(){
 
-		add_action( 'admin_notices', array($this, 'display_messages') );
 		add_action( 'admin_notices', array($this, 'validate_certificate') );
+		add_action( 'admin_notices', array($this, 'render_auto_invoice_notice') );
 		add_action( 'add_meta_boxes', array($this, 'register_metabox_nfe_emitida') );
 		add_action( 'admin_init', array($this, 'wmbr_compatibility_issues') );
 		add_action( 'add_meta_boxes', array($this, 'register_metabox_listar_nfe') );
@@ -21,7 +23,7 @@ class WooCommerceNFeBackend extends WooCommerceNFe {
 		add_action( 'woocommerce_order_actions', array( $this, 'add_order_meta_box_actions' ) );
 		add_action( 'woocommerce_order_action_wc_nfe_emitir', array( $this, 'process_order_meta_box_actions' ) );
 		add_action( 'admin_footer', array( $this, 'add_order_bulk_actions' ) );
-		add_action( 'init', array( $this, 'process_order_bulk_actions' ) );
+		add_action( 'admin_init', array( $this, 'process_order_bulk_actions' ) );
 		add_filter( 'woocommerce_settings_tabs_array', array($this, 'add_settings_tab'), 100 );
 		add_action( 'woocommerce_settings_tabs_woocommercenfe_tab', array($this, 'settings_tab'));
 		add_action( 'woocommerce_update_options_woocommercenfe_tab', array($this, 'update_settings' ));
@@ -34,6 +36,7 @@ class WooCommerceNFeBackend extends WooCommerceNFe {
 		add_action( 'admin_menu', array($this, 'add_admin_menu_item'));
 		add_action( 'admin_init', array($this, 'alert_auto_invoice_errors'));
 		add_action( 'wp_ajax_wmbr_remove_order_id_auto_invoice', array($this, 'wmbr_remove_order_id_auto_invoice'));
+		add_action( 'wp_ajax_wmbr_dismiss_auto_invoice_notice', array($this, 'wmbr_dismiss_auto_invoice_notice'));
 		add_filter( 'woocommerce_admin_shipping_fields', array($this, 'extra_shipping_fields') );
 		add_action( 'admin_enqueue_scripts', array($this, 'scripts') );
 		add_action( 'wp_ajax_force_digital_certificate_update', array($this, 'ajax_force_certificate_update') );
@@ -42,6 +45,7 @@ class WooCommerceNFeBackend extends WooCommerceNFe {
 		if (class_exists( \Automattic\WooCommerce\Utilities\OrderUtil::class ) && \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled()){
 			add_filter( 'manage_woocommerce_page_wc-orders_columns', array( $this, 'add_order_status_column_header' ), 20 );
 			add_action( 'manage_woocommerce_page_wc-orders_custom_column', array( $this, 'add_order_status_column_content' ), 10, 2 ); 
+			add_action( 'woocommerce_process_shop_order_meta', array($this, 'save_informacoes_fiscais'), 10, 1 );
 		}
 
 		// Legacy version
@@ -252,11 +256,11 @@ class WooCommerceNFeBackend extends WooCommerceNFe {
 
 	echo '<span id="update-digital-certificate-response">';
 		if ( isset($certificate->status) && $certificate->status == 'success' ) {
-			echo '<h4 class="cert_ajax_success">Faltam ' . $certificate->msg . ' dias para o Certificado Digital A1 expirar.</h4>';
+			echo '<h4 class="cert_ajax_success">Faltam ' . esc_html( (string) $certificate->msg ) . ' dias para o Certificado Digital A1 expirar.</h4>';
 		} elseif ( isset($certificate->status) && $certificate->status == 'error' ) {
 			echo '<h4 class="cert_ajax_error">Certificado Digital A1 expirado</h4>';
 		} elseif ( isset($certificate->status) && $certificate->status == 'null_credentials' ) {
-			echo '<h4 class="cert_ajax_error">'.$certificate->msg.'</h4>';
+			echo '<h4 class="cert_ajax_error">'.esc_html( (string) $certificate->msg ).'</h4>';
 		} else {
 			echo '<h4 class="cert_ajax_error">Informe as credenciais da API 1.0 para verificar o Certificado Digital A1.</h4>';
 		}
@@ -292,7 +296,7 @@ class WooCommerceNFeBackend extends WooCommerceNFe {
 		<?php echo $this->get_transportadoras_entries(); ?>
 	</div>
 	<button type="button" class="button-primary" id="wmbr-add-shipping-info">Adicionar Método de Entrega</button>
-	<input type="hidden" name="shipping-info-count" value="<?php echo count($transportadoras); ?>" />
+	<input type="hidden" name="shipping-info-count" value="<?php echo esc_attr( (string) count( $transportadoras ) ); ?>" />
 </div>
 
 	<?php
@@ -312,7 +316,8 @@ class WooCommerceNFeBackend extends WooCommerceNFe {
 <script type="text/javascript">
 jQuery(document).ready(function($) {
 	var data = {
-		'action': 'force_digital_certificate_update'
+		'action': 'force_digital_certificate_update',
+		'security': '<?php echo esc_js( wp_create_nonce( 'woocommerce_nfe_ajax' ) ); ?>'
 	};
 	$("#update-digital-certificate").click(function(){
 		var response = '';
@@ -346,18 +351,24 @@ jQuery(document).ready(function($) {
 
 		woocommerce_update_options( $this->get_settings() );
 
+		// Capability check for safety
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return;
+		}
+
 		// Vars
-		$count = (int) $_POST['shipping-info-count'];
+		$count = isset($_POST['shipping-info-count']) ? (int) $_POST['shipping-info-count'] : 0;
 		$transportadoras = array();
 		$payment_methods = array();
-		$patment_descs = array();
+		$payment_descs = array();
 		$cnpj_payment_methods = array();
 
 		if ($method = @$_POST['payment_method']){
 			$desc = @$_POST['payment_desc'];
 			foreach($method as $key => $value){
-				$payment_methods[$key] = sanitize_text_field($value);
-				$payment_descs[$key] = sanitize_text_field($desc[$key]);
+				$san_key = sanitize_text_field( (string) $key );
+				$payment_methods[$san_key] = sanitize_text_field($value);
+				$payment_descs[$san_key] = isset($desc[$key]) ? sanitize_text_field($desc[$key]) : '';
 			}
 		}
 
@@ -365,7 +376,7 @@ jQuery(document).ready(function($) {
 		if ($_POST){
 			for ($i = 1; $i < $count+1; $i++) {
 
-				$id = $_POST['shipping_info_method_'.$i];
+				$id = isset($_POST['shipping_info_method_'.$i]) ? sanitize_text_field($_POST['shipping_info_method_'.$i]) : '';
 				if (!$id) continue;
 				$transportadoras[$id] = array();
 				$keys = array(
@@ -379,7 +390,7 @@ jQuery(document).ready(function($) {
 				);
 
 				foreach($keys as $name => $post_key){
-					$transportadoras[$id][$name] = sanitize_text_field($_POST['shipping_info_'.$post_key.'_'.$i]);
+					$transportadoras[$id][$name] = isset($_POST['shipping_info_'.$post_key.'_'.$i]) ? sanitize_text_field($_POST['shipping_info_'.$post_key.'_'.$i]) : '';
 				}
 
 			}
@@ -741,13 +752,13 @@ jQuery(document).ready(function($) {
 			$html .= '<div class="entry">';
 			$html .= '<div class="shipping-method-col">'.$this->get_shipping_methods_select($i, $key).'</div>';
 			$html .= '<div class="shipping-info-col">';
-			$html .= '<p><label class="nfe-shipping-label">Razão Social: </label><input type="text" name="shipping_info_rs_'.$i.'" value="'.$transp['razao_social'].'"/></p>';
-			$html .= '<p><label class="nfe-shipping-label">CNPJ: </label><input type="text" name="shipping_info_cnpj_'.$i.'" value="'.$transp['cnpj'].'"/></p>';
-			$html .= '<p><label class="nfe-shipping-label">Inscrição estadual: </label><input type="text" name="shipping_info_ie_'.$i.'" value="'.$transp['ie'].'"/></p>';
-			$html .= '<p><label class="nfe-shipping-label">Endereço: </label><input type="text" name="shipping_info_address_'.$i.'" value="'.$transp['address'].'"/></p>';
-			$html .= '<p><label class="nfe-shipping-label">CEP: </label><input type="text" name="shipping_info_cep_'.$i.'" value="'.$transp['cep'].'"/></p>';
-			$html .= '<p><label class="nfe-shipping-label">Cidade: </label><input type="text" name="shipping_info_city_'.$i.'" value="'.$transp['city'].'"/></p>';
-			$html .= '<p><label class="nfe-shipping-label">UF: </label><input type="text" name="shipping_info_uf_'.$i.'" value="'.$transp['uf'].'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">Razão Social: </label><input type="text" name="shipping_info_rs_'.$i.'" value="'.esc_attr( isset($transp['razao_social']) ? $transp['razao_social'] : '' ).'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">CNPJ: </label><input type="text" name="shipping_info_cnpj_'.$i.'" value="'.esc_attr( isset($transp['cnpj']) ? $transp['cnpj'] : '' ).'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">Inscrição estadual: </label><input type="text" name="shipping_info_ie_'.$i.'" value="'.esc_attr( isset($transp['ie']) ? $transp['ie'] : '' ).'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">Endereço: </label><input type="text" name="shipping_info_address_'.$i.'" value="'.esc_attr( isset($transp['address']) ? $transp['address'] : '' ).'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">CEP: </label><input type="text" name="shipping_info_cep_'.$i.'" value="'.esc_attr( isset($transp['cep']) ? $transp['cep'] : '' ).'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">Cidade: </label><input type="text" name="shipping_info_city_'.$i.'" value="'.esc_attr( isset($transp['city']) ? $transp['city'] : '' ).'"/></p>';
+			$html .= '<p><label class="nfe-shipping-label">UF: </label><input type="text" name="shipping_info_uf_'.$i.'" value="'.esc_attr( isset($transp['uf']) ? $transp['uf'] : '' ).'"/></p>';
 			$html .= '<button type="button" class="button wmbr-remove-shipping-info"><span class="dashicons dashicons-no"></span> Remover</button>';
 			$html .= '</div>';
 			$html .= '</div>';
@@ -768,7 +779,7 @@ jQuery(document).ready(function($) {
 
 		// Vars
 		$carriers = get_option('wc_settings_woocommercenfe_transportadoras', array());
-		$html = '<select class="nfe-shipping-methods-sel" name="shipping_info_method_'.$index.'">';
+		$html = '<select class="nfe-shipping-methods-sel" name="shipping_info_method_'.esc_attr( (string) $index ).'">';
 		$html .= '<option value="">Selecionar</option>';
 
 		// Shipping Methods
@@ -799,7 +810,7 @@ jQuery(document).ready(function($) {
 					if ($id){
 						((isset($carriers['FRENET_'.$var->ServiceCode]) && $id == 'FRENET_'.$var->ServiceCode) ? $selected = 'selected' : $selected = '');
 					}
-					$html .= '<option value="FRENET_'.$var->ServiceCode.'" '.$selected.'>Frenet - '.$var->Carrier.' ('.$var->ServiceDescription.')</option>';
+					$html .= '<option value="'.esc_attr( 'FRENET_'.$var->ServiceCode ).'" '.$selected.'>Frenet - '.esc_html( $var->Carrier ).' ('.esc_html( $var->ServiceDescription ).')</option>';
 
 				}
 
@@ -817,7 +828,7 @@ jQuery(document).ready(function($) {
 
 			}
 
-			$html .= '<option value="'.$method->id.'" '.$selected.'>'.$title.'</option>';
+			$html .= '<option value="'.esc_attr( $method->id ).'" '.$selected.'>'.esc_html( $title ).'</option>';
 
 		}
 
@@ -854,7 +865,7 @@ jQuery(document).ready(function($) {
 			'99' => 'Outros',
 		);
 
-		$html = '<select class="nfe-payment-methods-sel" name="payment_method['.$method.']">';
+		$html = '<select class="nfe-payment-methods-sel" name="payment_method['.esc_attr( $method ).']">';
 		$html .= '<option value="">Selecionar</option>';
 
 		foreach ($options as $value => $label) {
@@ -865,7 +876,7 @@ jQuery(document).ready(function($) {
 				$selected = 'selected';
 			}
 
-			$html .= '<option value="'.$value.'" '.$selected.'>'.$label.'</option>';
+			$html .= '<option value="'.esc_attr( $value ).'" '.$selected.'>'.esc_html( $label ).'</option>';
 
 		}
 
@@ -886,14 +897,14 @@ jQuery(document).ready(function($) {
 
 		$saved_values = get_option('wc_settings_woocommercenfe_payment_descs', array());
 
-		$html = '<input type="text" class="nfe-payment-desc" name="payment_desc['.$method.']" style="width: 400px; ';
+		$html = '<input type="text" class="nfe-payment-desc" name="payment_desc['.esc_attr( $method ).']" style="width: 400px; ';
 
 		if (!$is_method_99) {
 			$html .= 'display: none;';
 		} 
 
 		if (isset($saved_values[$method]) && $is_method_99) {
-			$html .= '" value="'.$saved_values[$method].'">';
+			$html .= '" value="'.esc_attr( $saved_values[$method] ).'">';
 		}
 		else {
 			$html .= '">';
@@ -942,7 +953,16 @@ jQuery(document).ready(function($) {
 			return false;
 		}
 
-		if ( isset($_GET['atualizar_nfe']) && $_GET['post'] && $_GET['chave']) {
+		if ( isset($_GET['atualizar_nfe']) && isset($_GET['post']) && isset($_GET['chave']) && isset($_GET['nonce']) ) {
+
+			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+				return false;
+			}
+
+			// Security: Verify nonce
+			if ( ! wp_verify_nonce( $_GET['nonce'], 'atualizar_nfe_' . $_GET['post'] ) ) {
+				wp_die( __( 'Security check failed', 'woocommerce' ) );
+			}
 
 			$this->get_credentials();
 			$post_id = (int) sanitize_text_field($_GET['post']);
@@ -958,7 +978,7 @@ jQuery(document).ready(function($) {
 			} else {
 
 				$new_status = $response->status;
-				$nfe_data = get_post_meta( $order->id, 'nfe', true );
+				$nfe_data = $order->get_meta('nfe');
 
 				foreach ($nfe_data as &$order_nfe) {
 
@@ -1023,9 +1043,9 @@ jQuery(document).ready(function($) {
 
 	$data_nfe = $order_nfe['data'];
 
-	$nfe_doc = $this->get_order_cpf_cnpj($order->ID, $order_nfe);
+	$nfe_doc = $this->get_order_cpf_cnpj($order, $order_nfe);
 	$uuid = isset($order_nfe['uuid']) ? $order_nfe['uuid'] : '';
-	$tokenData = $this->createSecureTokenDFe($nfe_doc, $uuid);
+	$tokenData = !empty($nfe_doc) ? $this->createSecureTokenDFe($nfe_doc, $uuid) : '';
 
 	if (isset($order_nfe['modelo']) && $order_nfe['modelo'] == 'nfse') {
 		$modelo_nfe = 'NFS-e';
@@ -1044,60 +1064,60 @@ jQuery(document).ready(function($) {
 	(isset($order_nfe['n_serie']) ? $serie_nfe = $order_nfe['n_serie'] : $serie_nfe = '' );
 	if ($status_nfe == 'processando') $status_nfe = 'processamento';
 	if ($modelo_nfe == 'NF-e'){
-		if (isset($order_nfe['url_danfe']) && $chave_acesso_nfe) $order_nfe['url_danfe'] = 'https://nfe.webmaniabr.com/danfe/'.$chave_acesso_nfe.'?token='.$tokenData;
-		if (isset($order_nfe['url_xml']) && $chave_acesso_nfe) $xml_nfe = 'https://nfe.webmaniabr.com/xmlnfe/'.$chave_acesso_nfe.'?download=1&token='.$tokenData;
+		if (isset($order_nfe['url_danfe']) && $chave_acesso_nfe) $order_nfe['url_danfe'] = 'https://nfe.webmaniabr.com/danfe/'.$chave_acesso_nfe.(!empty($tokenData) ? '?token='.$tokenData : '');
+		if (isset($order_nfe['url_xml']) && $chave_acesso_nfe) $xml_nfe = 'https://nfe.webmaniabr.com/xmlnfe/'.$chave_acesso_nfe.'?download=1'.(!empty($tokenData) ? '&token='.$tokenData : '');
 		if (isset($order_nfe['url_danfe_simplificada']) && isset($order_nfe['url_danfe'])) $order_nfe['url_danfe_simplificada'] = str_replace('/danfe/', '/danfe/simples/', $order_nfe['url_danfe']);
 		if (isset($order_nfe['url_danfe_etiqueta']) && isset($order_nfe['url_danfe'])) $order_nfe['url_danfe_etiqueta'] = str_replace('/danfe/', '/danfe/etiqueta/', $order_nfe['url_danfe']);
 	} else{
-		$xml_nfe = (!empty($order_nfe['url_xml']))? $order_nfe['url_xml'].'?token='.$tokenData : '';
+		$xml_nfe = (!empty($order_nfe['url_xml']))? $order_nfe['url_xml'].(!empty($tokenData) ? '?token='.$tokenData : '') : '';
 	}
 	if ($modelo_nfe == 'Lote RPS' && $status_nfe == 'processado') continue;
 	?>
 	<div class="single">
 		<div>
-		<h4 class="body-info"><?php echo $data_nfe; ?></h4>
-		<h4 class="body-info modelo-column"><?php echo $modelo_nfe; ?></h4>
-		<h4 class="body-info n-column"><?php echo $numero_nfe; ?></h4>
+		<h4 class="body-info"><?php echo esc_html( (string) $data_nfe ); ?></h4>
+		<h4 class="body-info modelo-column"><?php echo esc_html( (string) $modelo_nfe ); ?></h4>
+		<h4 class="body-info n-column"><?php echo esc_html( (string) $numero_nfe ); ?></h4>
 		<h4 class="body-info danfe-column">
 			<?php if ($modelo_nfe == 'Lote RPS') { ?>
 			<span>---</span>
 			<?php } else if ($modelo_nfe == 'NFS-e') {
 				if (isset($order_nfe['url_pdf']) && !empty($order_nfe['url_pdf'])) { ?>
-				<a class="unstyled" target="_blank" href="<?php echo $order_nfe['url_pdf'].'?token='.$tokenData ?>"><span class="wrt">PDF </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>
+				<a class="unstyled" target="_blank" href="<?php echo esc_url( $order_nfe['url_pdf'].(!empty($tokenData) ? '?token='.$tokenData : '') ); ?>"><span class="wrt">PDF </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>
 			<?php } elseif (isset($order_nfe['pdf_rps']) && !empty($order_nfe['pdf_rps'])) { ?>
-				<a class="unstyled" target="_blank" href="<?php echo $order_nfe['pdf_rps'].'?token='.$tokenData ?>"><span class="wrt">DARPS </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>
+				<a class="unstyled" target="_blank" href="<?php echo esc_url( $order_nfe['pdf_rps'].(!empty($tokenData) ? '?token='.$tokenData : '') ); ?>"><span class="wrt">DARPS </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>
 			<?php }
 			} else { ?>
 			<?php if (isset($order_nfe['url_danfe'])) { ?>
-				<a class="unstyled" target="_blank" href="<?php echo $order_nfe['url_danfe'] ?>"><span class="wrt">Danfe </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>|
+				<a class="unstyled" target="_blank" href="<?php echo esc_url( $order_nfe['url_danfe'] ); ?>"><span class="wrt">Danfe </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>|
 			<?php } if (isset($order_nfe['url_danfe_simplificada'])) { ?>
-				<a class="unstyled" target="_blank" href="<?php echo $order_nfe['url_danfe_simplificada'] ?>"><span class="wrt"> Danfe Simples </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>|
+				<a class="unstyled" target="_blank" href="<?php echo esc_url( $order_nfe['url_danfe_simplificada'] ); ?>"><span class="wrt"> Danfe Simples </span><span class="dashicons dashicons-media-text danfe-icon"></span></a>|
 			<?php } if (isset($order_nfe['url_danfe_etiqueta'])) { ?>
-				<a class="unstyled" target="_blank" href="<?php echo $order_nfe['url_danfe_etiqueta'] ?>"><span class="wrt"> Danfe Etiqueta</span><span class="dashicons dashicons-media-text danfe-icon"></span></a>
+				<a class="unstyled" target="_blank" href="<?php echo esc_url( $order_nfe['url_danfe_etiqueta'] ); ?>"><span class="wrt"> Danfe Etiqueta</span><span class="dashicons dashicons-media-text danfe-icon"></span></a>
 			<?php }
 			} ?>
 		</h4>
 		<?php
-			$post_url = get_edit_post_link($order->ID);
+			$post_url = get_edit_post_link($order->get_id());
 			$update_url = $post_url.'&atualizar_nfe=true&chave='.$chave_acesso_nfe;
 		?>
-		<h4 class="body-info status-column"><span class="nfe-status <?php echo $status_nfe; ?>"><?php echo $status_nfe; ?></span>
-		<?php if (!in_array($modelo_nfe, ['NFS-e', 'Lote RPS'])) { ?><a class="unstyled" href="<?php echo $update_url; ?>"><span class="dashicons dashicons-image-rotate update-nfe"></span></a><?php } ?>
+		<h4 class="body-info status-column"><span class="nfe-status <?php echo esc_attr( (string) $status_nfe ); ?>"><?php echo esc_html( (string) $status_nfe ); ?></span>
+		<?php if (!in_array($modelo_nfe, ['NFS-e', 'Lote RPS'])) { ?><a class="unstyled" href="<?php echo esc_url( $update_url ); ?>"><span class="dashicons dashicons-image-rotate update-nfe"></span></a><?php } ?>
 		</h4></div>
 		<div class="extra">
 			<ul>
-			  <?php if ($chave_acesso_nfe) { ?><li><strong>Chave:</strong> <?php echo $chave_acesso_nfe; ?></li><?php } ?>
-				<?php if ($recibo_nfe) { ?><li><strong>Recibo:</strong> <?php echo $recibo_nfe; ?></li><?php } ?>
+			  <?php if ($chave_acesso_nfe) { ?><li><strong>Chave:</strong> <?php echo esc_html( (string) $chave_acesso_nfe ); ?></li><?php } ?>
+				<?php if ($recibo_nfe) { ?><li><strong>Recibo:</strong> <?php echo esc_html( (string) $recibo_nfe ); ?></li><?php } ?>
 				<?php if ($modelo_nfe != 'Lote RPS') { ?>
-					<li><strong>Série:</strong> <?php echo $serie_nfe ?></li>
+					<li><strong>Série:</strong> <?php echo esc_html( (string) $serie_nfe ); ?></li>
 				<?php } 
 				if (empty($xml_nfe)){?>
 				<li><strong>Arquivo XML: </strong>Indisponível</li>
 				<?php } else { ?>
-				<li><strong>Arquivo XML:</strong> <a target="_blank" href="<?php echo $xml_nfe; ?>">Download XML</a></li>
+				<li><strong>Arquivo XML:</strong> <a target="_blank" href="<?php echo esc_url( $xml_nfe ); ?>">Download XML</a></li>
 				<?php } ?>
 				<?php if ($status_nfe == 'reprovado' && isset($order_nfe['motivo'])) { ?>
-					<li><strong>Motivo:</strong> <?php echo $order_nfe['motivo']; ?></li>
+					<li><strong>Motivo:</strong> <?php echo esc_html( (string) $order_nfe['motivo'] ); ?></li>
 				<?php } ?>
 			</ul>
 		</div>
@@ -1141,6 +1161,7 @@ jQuery(document).ready(function($) {
 		$info_intermediador_id = $order->get_meta( '_nfe_info_intermediador_id' );
 
 	?>
+	<?php wp_nonce_field( 'save_nfe_meta_box_' . $order->get_id(), 'nfe_meta_box_nonce' ); ?>
 	<script>
 		jQuery(function($){
 
@@ -1181,13 +1202,13 @@ jQuery(document).ready(function($) {
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Natureza da Operação</label>
 			</p>
-			<input type="text" name="natureza_operacao_pedido" value="<?php echo $order->get_meta( '_nfe_natureza_operacao_pedido' ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="natureza_operacao_pedido" value="<?php echo esc_attr( $order->get_meta( '_nfe_natureza_operacao_pedido' ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 		<div class="field outras_informacoes">
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Benefício Fiscal</label>
 			</p>
-			<input type="text" name="beneficio_fiscal_pedido" value="<?php echo $order->get_meta( '_nfe_beneficio_fiscal_pedido' ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="beneficio_fiscal_pedido" value="<?php echo esc_attr( $order->get_meta( '_nfe_beneficio_fiscal_pedido' ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 		<input type="hidden" name="wp_admin_nfe" value="1" />
 	</div>
@@ -1237,25 +1258,25 @@ jQuery(document).ready(function($) {
 			<p class="label" style="margin-bottom:8px;">
 				<label class="title">Volume</label>
 			</p>
-			<input type="text" name="transporte_volume" value="<?php echo $order->get_meta( '_nfe_transporte_volume' ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="transporte_volume" value="<?php echo esc_attr( $order->get_meta( '_nfe_transporte_volume' ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 		<div class="field transporte">
 			<p class="label" style="margin-bottom:8px;">
 				<label class="title">Espécie</label>
 			</p>
-			<input type="text" name="transporte_especie" value="<?php echo $order->get_meta( '_nfe_transporte_especie' ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="transporte_especie" value="<?php echo esc_attr( $order->get_meta( '_nfe_transporte_especie' ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 		<div class="field transporte">
 			<p class="label" style="margin-bottom:8px;">
 				<label class="title">Peso Bruto</label> (KG)
 			</p>
-			<input type="text" name="transporte_peso_bruto" value="<?php echo $order->get_meta( '_nfe_transporte_peso_bruto' ); ?>" style="width:100%;padding:5px;" placeholder="Ex: 50.210 = 50,210KG">
+			<input type="text" name="transporte_peso_bruto" value="<?php echo esc_attr( $order->get_meta( '_nfe_transporte_peso_bruto' ) ); ?>" style="width:100%;padding:5px;" placeholder="Ex: 50.210 = 50,210KG">
 		</div>
 		<div class="field transporte">
 			<p class="label" style="margin-bottom:8px;">
 				<label class="title">Peso Líquido</label> (KG)
 			</p>
-			<input type="text" name="transporte_peso_liquido" value="<?php echo $order->get_meta( '_nfe_transporte_peso_liquido' ); ?>" style="width:100%;padding:5px;" placeholder="Ex: 50.210 = 50,210KG">
+			<input type="text" name="transporte_peso_liquido" value="<?php echo esc_attr( $order->get_meta( '_nfe_transporte_peso_liquido' ) ); ?>" style="width:100%;padding:5px;" placeholder="Ex: 50.210 = 50,210KG">
 		</div>
 	</div>
 	<div class="field" style="margin-bottom:10px;">
@@ -1268,7 +1289,7 @@ jQuery(document).ready(function($) {
 		<p class="label" style="margin-bottom:8px;">
 			<label class="title">Parcelas</label>
 		</p>
-		<input type="number" name="nfe_installments_n" min="1" value="<?php echo $nfe_installments_n; ?>" style="width:100%;padding:5px;">
+		<input type="number" name="nfe_installments_n" min="1" value="<?php echo esc_attr( (string) $nfe_installments_n ); ?>" style="width:100%;padding:5px;">
 	</div>
 	<div class="nfe_installments block">
 
@@ -1277,13 +1298,13 @@ jQuery(document).ready(function($) {
 				<p class="label">
 					<label class="title">Vencimento (DD/MM/AAAA)</label>
 				</p>
-				<input type="text" name="nfe_installments_due_date[]" value="<?php echo ($nfe_installments_due_date) ? $nfe_installments_due_date[0] : ''; ?>" style="width:100%;">
+				<input type="text" name="nfe_installments_due_date[]" value="<?php echo ($nfe_installments_due_date) ? esc_attr( (string) $nfe_installments_due_date[0] ) : ''; ?>" style="width:100%;">
 			</div>
 			<div class="field">
 				<p class="label">
 					<label class="title">Valor (R$)</label>
 				</p>
-				<input type="text" name="nfe_installments_value[]" value="<?php echo ($nfe_installments_value) ? $nfe_installments_value[0] : ''; ?>" style="width:100%;">
+				<input type="text" name="nfe_installments_value[]" value="<?php echo ($nfe_installments_value) ? esc_attr( (string) $nfe_installments_value[0] ) : ''; ?>" style="width:100%;">
 			</div>
 		</div>
 
@@ -1297,13 +1318,13 @@ jQuery(document).ready(function($) {
 				<p class="label">
 					<label class="title">Vencimento (DD/MM/AAAA)</label>
 				</p>
-				<input type="text" name="nfe_installments_due_date[]" value="<?php echo $nfe_installments_due_date[$i]; ?>" style="width:100%;">
+				<input type="text" name="nfe_installments_due_date[]" value="<?php echo esc_attr( (string) $nfe_installments_due_date[$i] ); ?>" style="width:100%;">
 			</div>
 			<div class="field">
 				<p class="label">
 					<label class="title">Valor (R$)</label>
 				</p>
-				<input type="text" name="nfe_installments_value[]" value="<?php echo $nfe_installments_value[$i]; ?>" style="width:100%;">
+				<input type="text" name="nfe_installments_value[]" value="<?php echo esc_attr( (string) $nfe_installments_value[$i] ); ?>" style="width:100%;">
 			</div>
 		</div>
 
@@ -1334,13 +1355,13 @@ jQuery(document).ready(function($) {
 			<p class="label">
 				<label class="title">CNPJ do Intermediador</label>
 			</p>
-			<input type="text" name="nfe_info_intermediador_cnpj" style="width:100%;" value="<?php echo $info_intermediador_cnpj ?>" />
+			<input type="text" name="nfe_info_intermediador_cnpj" style="width:100%;" value="<?php echo esc_attr( (string) $info_intermediador_cnpj ) ?>" />
 		</div>
 		<div class="field">
 			<p class="label">
 				<label class="title">ID do Intermediador</label>
 			</p>
-			<input type="text" name="nfe_info_intermediador_id" style="width:100%;" value="<?php echo $info_intermediador_id ?>" />
+			<input type="text" name="nfe_info_intermediador_id" style="width:100%;" value="<?php echo esc_attr( (string) $info_intermediador_id ) ?>" />
 		</div>
 	</div>
 
@@ -1351,7 +1372,7 @@ jQuery(document).ready(function($) {
 		</p>
 	</div>
 	<div class="field nfe_additional_info_text">
-		<textarea type="text" name="nfe_additional_info_text" rows="6" style="width:100%;padding:5px;"><?php echo $nfe_additional_info_text; ?></textarea>
+		<textarea type="text" name="nfe_additional_info_text" rows="6" style="width:100%;padding:5px;"><?php echo esc_textarea( (string) $nfe_additional_info_text ); ?></textarea>
 	</div>
 
 	<div class="field" style="margin-bottom:10px;">
@@ -1361,7 +1382,7 @@ jQuery(document).ready(function($) {
 		</p>
 	</div>
 	<div class="field nfe_service_info_text">
-		<textarea type="text" name="nfe_service_info_text" rows="6" style="width:100%;padding:5px;"><?php echo $nfe_service_info_text; ?></textarea>
+		<textarea type="text" name="nfe_service_info_text" rows="6" style="width:100%;padding:5px;"><?php echo esc_textarea( (string) $nfe_service_info_text ); ?></textarea>
 	</div>
 
 			<?php
@@ -1397,6 +1418,7 @@ jQuery(document).ready(function($) {
 		$others_checked = get_post_meta( $post->ID, '_nfe_product_others', true );
 
 	?>
+	<?php wp_nonce_field( 'save_nfe_meta_box_' . $post->ID, 'nfe_meta_box_nonce' ); ?>
 	<script>
 		jQuery(function($){
 
@@ -1433,7 +1455,7 @@ jQuery(document).ready(function($) {
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Tipo de produto</label>
 			</p>
-			<select name="tipo_produto" value="<?php echo get_post_meta( $post->ID, '_nfe_tipo_produto', true ); ?>" style="width:100%;padding:5px;">
+			<select name="tipo_produto" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_tipo_produto', true ) ); ?>" style="width:100%;padding:5px;">
 				<option value="1" <?php if (get_post_meta( $post->ID, '_nfe_tipo_produto', true ) == 1) echo 'selected'; ?>>Produto físico</option>
 				<option value="2" <?php if (get_post_meta( $post->ID, '_nfe_tipo_produto', true ) == 2) echo 'selected'; ?>>Prestação de serviço</option>
 			</select>
@@ -1442,20 +1464,20 @@ jQuery(document).ready(function($) {
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Classe de Imposto</label>
 			</p>
-			<input type="text" name="classe_imposto" value="<?php echo get_post_meta( $post->ID, '_nfe_classe_imposto', true ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="classe_imposto" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_classe_imposto', true ) ); ?>" style="width:100%;padding:5px;">
 	</div>
 	<div class="nfe_fields">
 	<div class="field">
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Código NCM</label>
 			</p>
-			<input type="text" name="codigo_ncm" value="<?php echo get_post_meta( $post->ID, '_nfe_codigo_ncm', true ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="codigo_ncm" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_codigo_ncm', true ) ); ?>" style="width:100%;padding:5px;">
 	</div>
 	<div class="field">
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Código CEST</label>
 			</p>
-			<input type="text" name="codigo_cest" value="<?php echo get_post_meta( $post->ID, '_nfe_codigo_cest', true ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="codigo_cest" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_codigo_cest', true ) ); ?>" style="width:100%;padding:5px;">
 	</div>
 	<div class="field">
 		<p class="label" style="margin-bottom:8px;">
@@ -1531,7 +1553,7 @@ jQuery(document).ready(function($) {
 			<?php
 			foreach ($lista_unidades as $k => $v) {
 				?>
-				<option value="<?php echo $k;?>" <?php if ($unidade == $k) echo 'selected'; ?> ><?php echo $v; ?></option>
+				<option value="<?php echo esc_attr( (string) $k );?>" <?php if ($unidade == $k) echo 'selected'; ?> ><?php echo esc_html( (string) $v ); ?></option>
 				<?php
 			}
 			?>
@@ -1562,7 +1584,7 @@ jQuery(document).ready(function($) {
 			<p class="label" style="margin-bottom:8px;">
 					<label class="title">Informações adicionais do produto</label>
 			</p>
-			<input type="text" name="produto_informacoes_adicionais" value="<?php echo get_post_meta( $post->ID, '_nfe_produto_informacoes_adicionais', true ); ?>" style="width:100%;padding:5px;">
+			<input type="text" name="produto_informacoes_adicionais" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_produto_informacoes_adicionais', true ) ); ?>" style="width:100%;padding:5px;">
 	</div>
 	<div class="field" style="margin-bottom:10px;">
 		<p class="label" style="margin-bottom:8px;">
@@ -1575,13 +1597,13 @@ jQuery(document).ready(function($) {
 				<p class="label" style="margin-bottom:8px;">
 						<label class="title">GTIN</label>
 				</p>
-				<input type="text" name="codigo_ean" value="<?php echo get_post_meta( $post->ID, '_nfe_codigo_ean', true ); ?>" style="width:100%;padding:5px;">
+				<input type="text" name="codigo_ean" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_codigo_ean', true ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 		<div class="field">
 				<p class="label" style="margin-bottom:8px;">
 						<label class="title">GTIN tributável</label>
 				</p>
-				<input type="text" name="gtin_tributavel" value="<?php echo get_post_meta( $post->ID, '_nfe_gtin_tributavel', true ); ?>" style="width:100%;padding:5px;">
+				<input type="text" name="gtin_tributavel" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_gtin_tributavel', true ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 		<div class="field">
 				<p class="label" style="margin-bottom:8px;">
@@ -1601,7 +1623,7 @@ jQuery(document).ready(function($) {
 				<p class="label" style="margin-bottom:8px;">
 						<label class="title">CNPJ do Fabricante</label>
 				</p>
-				<input type="text" name="cnpj_fabricante" value="<?php echo get_post_meta( $post->ID, '_nfe_cnpj_fabricante', true ); ?>" style="width:100%;padding:5px;">
+				<input type="text" name="cnpj_fabricante" value="<?php echo esc_attr( get_post_meta( $post->ID, '_nfe_cnpj_fabricante', true ) ); ?>" style="width:100%;padding:5px;">
 		</div>
 	</div>
 	</div>
@@ -1732,6 +1754,16 @@ jQuery(document).ready(function($) {
 					$( 'select[name^="action"]' ).append( $imprimir_danfe );
 					$( 'select[name^="action"]' ).append( $imprimir_simplificada );
 					$( 'select[name^="action"]' ).append( $imprimir_etiqueta );
+
+					var bulkNonce = '<?php echo esc_js( wp_create_nonce( 'wmbr_bulk_order_actions' ) ); ?>';
+					$( '#posts-filter, #wc-orders-filter' ).each( function() {
+						var $form = $( this );
+						if ( $form.find('input[name="wmbr_bulk_order_actions_nonce"]').length === 0 ) {
+							$('<input>')
+								.attr({ type: 'hidden', name: 'wmbr_bulk_order_actions_nonce', value: bulkNonce })
+								.appendTo( $form );
+						}
+					});
 				});
 			</script>
 			<?php
@@ -1770,19 +1802,48 @@ jQuery(document).ready(function($) {
 	 */
 	function process_order_bulk_actions(){
 
+		// Security: only process from wp-admin and authorized users
+		if ( ! is_admin() ) {
+			return false;
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			return false;
+		}
+
 		$order_list = $_GET['post_type'] ?? $_GET['page'] ?? [];
 
 		if (!$order_list) return;
 
-		if ( isset( $order_list ) && in_array($order_list, ['shop_order', 'wc-orders']) && isset( $_GET['action'] ) ) {
+		if ( isset( $order_list ) && in_array($order_list, ['shop_order', 'wc-orders']) ) {
 
-			// Verify selected action
-			if ( ! isset( $_GET['action'] ) || ! in_array( $_GET['action'], array( 'wc_nfe_emitir', 'wc_nfe_imprimir_danfe', 'wc_nfe_imprimir_simplificada', 'wc_nfe_imprimir_etiqueta') ) ) return false;
-			
-			isset( $_GET['action'] )? $action = $_GET['action'] : '';
+			// Resolve selected action (WP uses action + action2; often action=-1 when none is selected)
+			$action  = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
+			$action2 = isset( $_GET['action2'] ) ? sanitize_text_field( wp_unslash( $_GET['action2'] ) ) : '';
+			if ( empty( $action ) || '-1' === $action ) {
+				$action = $action2;
+			}
+
+			// Verify selected action (only proceed for plugin actions)
+			$allowed_actions = array( 'wc_nfe_emitir', 'wc_nfe_imprimir_danfe', 'wc_nfe_imprimir_simplificada', 'wc_nfe_imprimir_etiqueta' );
+			if ( ! $action || ! in_array( $action, $allowed_actions, true ) ) {
+				return false;
+			}
+
+			// Security: Verify nonce ONLY for plugin actions (prevents notice spam on action=-1)
+			$bulk_nonce = isset( $_GET['wmbr_bulk_order_actions_nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['wmbr_bulk_order_actions_nonce'] ) ) : '';
+			if ( ! $bulk_nonce || ! wp_verify_nonce( $bulk_nonce, 'wmbr_bulk_order_actions' ) ) {
+				$reason = __( '<strong>[WebmaniaBR® Nota Fiscal] Aviso:</strong> Não foi possível validar a ação. Atualize a página e tente novamente.', $this->domain );
+				$this->add_error( $reason );
+				return false;
+			}
 
 			// Verify order IDs
-			$order_ids = array_map('absint', $_GET['id'] ?? $_GET['post'] ?? []);
+			$order_ids_raw = $_GET['id'] ?? $_GET['post'] ?? [];
+			if ( ! is_array( $order_ids_raw ) ) {
+				$order_ids_raw = array( $order_ids_raw );
+			}
+			$order_ids = array_filter( array_map( 'absint', $order_ids_raw ) );
 
 			if ( !$order_ids ){
 				$reason = __( '<strong>[WebmaniaBR® Nota Fiscal] Aviso:</strong> Selecione <strong>no mínimo um pedido</strong> para executar esta ação.');
@@ -2231,20 +2292,30 @@ jQuery(document).ready(function($) {
 	 */
     function save_informacoes_fiscais( $post_id ){
 
-			if (get_post_type($post_id) == 'product' && $_POST['wp_admin_nfe']){
+			// Security: Check user capabilities
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
+				return;
+			}
+
+			// Security: Verify nonce for CSRF protection
+			if ( ! isset( $_POST['nfe_meta_box_nonce'] ) || ! wp_verify_nonce( $_POST['nfe_meta_box_nonce'], 'save_nfe_meta_box_' . $post_id ) ) {
+				return;
+			}
+
+			if (get_post_type($post_id) == 'product' && !empty($_POST['wp_admin_nfe'])){
 
 					$info = array(
-					'_nfe_tipo_produto'    => $_POST['tipo_produto'],
-					'_nfe_classe_imposto'  => $_POST['classe_imposto'],
-					'_nfe_codigo_ean'      => $_POST['codigo_ean'],
-					'_nfe_gtin_tributavel' => $_POST['gtin_tributavel'],
-					'_nfe_codigo_ncm'      => $_POST['codigo_ncm'],
-					'_nfe_codigo_cest'     => $_POST['codigo_cest'],
-					'_nfe_cnpj_fabricante' => $_POST['cnpj_fabricante'],
-					'_nfe_ind_escala'      => $_POST['ind_escala'],
-					'_nfe_produto_informacoes_adicionais' => $_POST['produto_informacoes_adicionais'],
-					'_nfe_unidade'         => $_POST['unidade'],
-					'_nfe_product_others'  => $_POST['product_others']
+					'_nfe_tipo_produto'    => sanitize_text_field($_POST['tipo_produto'] ?? ''),
+					'_nfe_classe_imposto'  => sanitize_text_field($_POST['classe_imposto'] ?? ''),
+					'_nfe_codigo_ean'      => sanitize_text_field($_POST['codigo_ean'] ?? ''),
+					'_nfe_gtin_tributavel' => sanitize_text_field($_POST['gtin_tributavel'] ?? ''),
+					'_nfe_codigo_ncm'      => sanitize_text_field($_POST['codigo_ncm'] ?? ''),
+					'_nfe_codigo_cest'     => sanitize_text_field($_POST['codigo_cest'] ?? ''),
+					'_nfe_cnpj_fabricante' => sanitize_text_field($_POST['cnpj_fabricante'] ?? ''),
+					'_nfe_ind_escala'      => sanitize_text_field($_POST['ind_escala'] ?? ''),
+					'_nfe_produto_informacoes_adicionais' => sanitize_text_field($_POST['produto_informacoes_adicionais'] ?? ''),
+					'_nfe_unidade'         => sanitize_text_field($_POST['unidade'] ?? ''),
+					'_nfe_product_others'  => sanitize_text_field($_POST['product_others'] ?? '')
 					);
 
 					foreach ($info as $key => $value){
@@ -2253,8 +2324,8 @@ jQuery(document).ready(function($) {
 						}
 					}
 
-					if ($_POST['ignorar_nfe']){
-						update_post_meta( $post_id, '_nfe_ignorar_nfe', $_POST['ignorar_nfe'] );
+					if (!empty($_POST['ignorar_nfe'])){
+						update_post_meta( $post_id, '_nfe_ignorar_nfe', sanitize_text_field($_POST['ignorar_nfe']) );
 					} else {
 						update_post_meta( $post_id, '_nfe_ignorar_nfe', 0 );
 					}
@@ -2263,39 +2334,39 @@ jQuery(document).ready(function($) {
 						delete_post_meta( $post_id, '_nfe_product_others' );
 					}
 
-					if (is_numeric($_POST['origem']) || $_POST['origem']){
-						update_post_meta( $post_id, '_nfe_origem', $_POST['origem'] );
+					if (isset($_POST['origem']) && (is_numeric($_POST['origem']) || $_POST['origem'])){
+						update_post_meta( $post_id, '_nfe_origem', sanitize_text_field($_POST['origem']) );
 					}
 						
 			}
 
-			if (get_post_type($post_id) == 'shop_order' && $_POST && $_POST['wp_admin_nfe']){
+			if (get_post_type($post_id) == 'shop_order' && $_POST && !empty($_POST['wp_admin_nfe'])){
 
 				$order = wc_get_order( $post_id );
 
 				$info = array(
-					'_nfe_natureza_operacao_pedido'	=> $_POST['natureza_operacao_pedido'],
-					'_nfe_beneficio_fiscal_pedido'	=> $_POST['beneficio_fiscal_pedido'],
-					'_nfe_contribuinte' => $_POST['nfe_contribuinte'],
-					'_nfe_modalidade_frete' 		=> $_POST['modalidade_frete'],
-					'_nfse_tipo_desconto' 		=> $_POST['tipo_desconto'],
-					'_nfe_volume_weight' => isset($_POST['nfe_volume_weight']) ? $_POST['nfe_volume_weight'] : false,
-					'_nfe_transporte_volume'    	=> $_POST['transporte_volume'],
-					'_nfe_transporte_especie'   	=> $_POST['transporte_especie'],
-					'_nfe_transporte_peso_bruto'    => $_POST['transporte_peso_bruto'],
-					'_nfe_transporte_peso_liquido'  => $_POST['transporte_peso_liquido'],
-					'_nfe_installments'  => isset($_POST['nfe_installments']) ? $_POST['nfe_installments'] : false,
-					'_nfe_installments_n'  => $_POST['nfe_installments_n'],
-					'_nfe_installments_due_date'  => $_POST['nfe_installments_due_date'],
-					'_nfe_installments_value'  => $_POST['nfe_installments_value'],
-					'_nfe_additional_info' => isset($_POST['nfe_additional_info']) ? $_POST['nfe_additional_info'] : false,
-					'_nfe_additional_info_text' => $_POST['nfe_additional_info_text'],
-					'_nfe_service_info' => isset($_POST['nfe_service_info']) ? $_POST['nfe_service_info'] : false,
-					'_nfe_service_info_text' => $_POST['nfe_service_info_text'],
-					'_nfe_info_intermediador' => isset($_POST['nfe_info_intermediador']) ? $_POST['nfe_info_intermediador'] : false,
-					'_nfe_info_intermediador_type' => $_POST['nfe_info_intermediador_type'],
-					'_nfe_info_intermediador_cnpj' => $_POST['nfe_info_intermediador_cnpj'],
-					'_nfe_info_intermediador_id' => $_POST['nfe_info_intermediador_id'],
+					'_nfe_natureza_operacao_pedido'	=> sanitize_text_field($_POST['natureza_operacao_pedido'] ?? ''),
+					'_nfe_beneficio_fiscal_pedido'	=> sanitize_text_field($_POST['beneficio_fiscal_pedido'] ?? ''),
+					'_nfe_contribuinte' => sanitize_text_field($_POST['nfe_contribuinte'] ?? ''),
+					'_nfe_modalidade_frete'		=> sanitize_text_field($_POST['modalidade_frete'] ?? ''),
+					'_nfse_tipo_desconto'		=> sanitize_text_field($_POST['tipo_desconto'] ?? ''),
+					'_nfe_volume_weight' => isset($_POST['nfe_volume_weight']) ? sanitize_text_field($_POST['nfe_volume_weight']) : false,
+					'_nfe_transporte_volume'		=> sanitize_text_field($_POST['transporte_volume'] ?? ''),
+					'_nfe_transporte_especie'		=> sanitize_text_field($_POST['transporte_especie'] ?? ''),
+					'_nfe_transporte_peso_bruto'    => sanitize_text_field($_POST['transporte_peso_bruto'] ?? ''),
+					'_nfe_transporte_peso_liquido'  => sanitize_text_field($_POST['transporte_peso_liquido'] ?? ''),
+					'_nfe_installments'  => isset($_POST['nfe_installments']) ? (bool) $_POST['nfe_installments'] : false,
+					'_nfe_installments_n'  => isset($_POST['nfe_installments_n']) ? (int) $_POST['nfe_installments_n'] : 0,
+					'_nfe_installments_due_date'  => isset($_POST['nfe_installments_due_date']) ? array_map('sanitize_text_field', (array) $_POST['nfe_installments_due_date']) : [],
+					'_nfe_installments_value'  => isset($_POST['nfe_installments_value']) ? array_map('sanitize_text_field', (array) $_POST['nfe_installments_value']) : [],
+					'_nfe_additional_info' => isset($_POST['nfe_additional_info']) ? (bool) $_POST['nfe_additional_info'] : false,
+					'_nfe_additional_info_text' => sanitize_text_field($_POST['nfe_additional_info_text'] ?? ''),
+					'_nfe_service_info' => isset($_POST['nfe_service_info']) ? (bool) $_POST['nfe_service_info'] : false,
+					'_nfe_service_info_text' => sanitize_text_field($_POST['nfe_service_info_text'] ?? ''),
+					'_nfe_info_intermediador' => isset($_POST['nfe_info_intermediador']) ? (bool) $_POST['nfe_info_intermediador'] : false,
+					'_nfe_info_intermediador_type' => sanitize_text_field($_POST['nfe_info_intermediador_type'] ?? ''),
+					'_nfe_info_intermediador_cnpj' => sanitize_text_field($_POST['nfe_info_intermediador_cnpj'] ?? ''),
+					'_nfe_info_intermediador_id' => sanitize_text_field($_POST['nfe_info_intermediador_id'] ?? '')
 				);
 
 				if (!$info['_nfe_volume_weight']){
@@ -2373,7 +2444,7 @@ jQuery(document).ready(function($) {
 				<label>NCM</label>
 			</th>
 			<td>
-				<input name="term-ncm" id="term-ncm" type="text" size="40" value="<?php echo $ncm; ?>"/>
+				<input name="term-ncm" id="term-ncm" type="text" size="40" value="<?php echo esc_attr( (string) $ncm ); ?>"/>
 				<p class="description">Este valor será utilizado caso o NCM não esteja definido diretamente no produto. Se vazio, será utilizado o NCM geral definido nas configurações da Nota Fiscal.</p>
 			</td>
 		</div>
@@ -2389,7 +2460,7 @@ jQuery(document).ready(function($) {
 	function save_product_cat_ncm( $term_id, $tag_id ){
 
 		if ( isset( $_POST['term-ncm'] ) ) {
-			update_term_meta( $term_id, '_ncm', $_POST['term-ncm']);
+			update_term_meta( $term_id, '_ncm', sanitize_text_field( $_POST['term-ncm'] ) );
 		}
 
 	}
@@ -2442,7 +2513,7 @@ jQuery(document).ready(function($) {
 
 		if ($post_type == 'product' && !$this->is_categories_ncm_valid($post->ID)){ ?>
 
-			<div class="error" style="background-color: #f2dede; color: #a94442;"><p><strong>Atenção:</strong> Duas ou mais categorias deste produto possuem o NCM definido e, caso diferentes, podem ter o valor incorreto durante a emissão da NF-e.</p></div>
+			<div class="notice notice-error is-dismissible" style="background-color: #f2dede; color: #a94442;"><p><strong>Atenção:</strong> Duas ou mais categorias deste produto possuem o NCM definido e, caso diferentes, podem ter o valor incorreto durante a emissão da NF-e.</p></div>
 
 		<?php }
 
@@ -2497,15 +2568,111 @@ jQuery(document).ready(function($) {
 
 		$ids_db = get_option('wmbr_auto_invoice_errors');
 
-		if ( !empty($ids_db) ) {
-
-			$menu_url = get_admin_url(get_current_blog_id(), '/admin.php?page=wmbr_page_auto_invoice_errors');
-			$message = __( '<strong>[WebmaniaBR® Nota Fiscal] Aviso:</strong> Foram localizados pedidos com erros de emissão. <a href="'.$menu_url.'">Visualizar Pedidos</a>');
-
-			$this->add_error( $message );
-
+		if ( empty($ids_db) ) {
+			return;
 		}
 
+		$notice_key = $this->get_auto_invoice_notice_key( $ids_db );
+		$dismissed_key = get_user_meta( get_current_user_id(), 'wmbr_dismiss_auto_invoice_notice', true );
+
+		if ( $dismissed_key === $notice_key ) {
+			return;
+		}
+
+		$menu_url = get_admin_url(get_current_blog_id(), '/admin.php?page=wmbr_page_auto_invoice_errors');
+		$message = __( '<strong>[WebmaniaBR® Nota Fiscal] Aviso:</strong> Foram localizados pedidos com erros de emissão. <a href="'.$menu_url.'">Visualizar Pedidos</a>');
+
+		$this->auto_invoice_notice = array(
+			'message' => $message,
+			'key' => $notice_key,
+		);
+
+	}
+
+	/**
+	 * Render dismissible notice for auto invoice errors.
+	 *
+	 * @return void
+	 */
+	public function render_auto_invoice_notice() {
+
+		if ( empty( $this->auto_invoice_notice ) ) {
+			return;
+		}
+
+		$notice = $this->auto_invoice_notice;
+		$nonce = wp_create_nonce( 'wmbr_dismiss_auto_invoice_notice' );
+		?>
+		<div class="notice notice-error is-dismissible wmbr-auto-invoice-notice" data-notice-key="<?php echo esc_attr( (string) $notice['key'] ); ?>" data-sec-nonce="<?php echo esc_attr( (string) $nonce ); ?>">
+			<p>
+				<?php
+				// Security: Allow specific HTML tags in admin notices
+				echo wp_kses( $notice['message'], array(
+					'strong' => array(),
+					'a' => array( 'href' => array(), 'target' => array() ),
+					'ul' => array(),
+					'li' => array()
+				) );
+				?>
+			</p>
+		</div>
+		<script>
+			jQuery(function($){
+				$(document).on('click', '.wmbr-auto-invoice-notice .notice-dismiss', function(){
+					var $notice = $(this).closest('.wmbr-auto-invoice-notice');
+					$.post(ajaxurl, {
+						action: 'wmbr_dismiss_auto_invoice_notice',
+						sec_nonce: $notice.data('sec-nonce'),
+						notice_key: $notice.data('notice-key')
+					});
+				});
+			});
+		</script>
+		<?php
+	}
+
+	/**
+	 * Dismiss auto invoice notice per user.
+	 *
+	 * @return void
+	 */
+	public function wmbr_dismiss_auto_invoice_notice() {
+
+		// Security: Check proper nonce and capabilities
+		if ( ! check_ajax_referer( 'wmbr_dismiss_auto_invoice_notice', 'sec_nonce', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed', 'woocommerce' ) ), 403 );
+			wp_die();
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'woocommerce' ) ), 403 );
+			wp_die();
+		}
+
+		$notice_key = isset($_POST['notice_key']) ? sanitize_text_field( wp_unslash( $_POST['notice_key'] ) ) : '';
+		if ( !$notice_key ) {
+			wp_send_json_error( array( 'message' => 'Invalid notice key' ), 400 );
+			wp_die();
+		}
+
+		update_user_meta( get_current_user_id(), 'wmbr_dismiss_auto_invoice_notice', $notice_key );
+
+		wp_send_json_success( array( 'message' => 'Notice dismissed' ) );
+		wp_die();
+	}
+
+	/**
+	 * Build notice key for auto invoice errors.
+	 *
+	 * @param array $ids_db
+	 * @return string
+	 */
+	private function get_auto_invoice_notice_key( $ids_db ) {
+
+		$order_ids = array_map( 'strval', array_keys( (array) $ids_db ) );
+		sort( $order_ids );
+
+		return md5( wp_json_encode( $order_ids ) );
 	}
 
 	/**
@@ -2515,25 +2682,32 @@ jQuery(document).ready(function($) {
 	 */
 	public function wmbr_remove_order_id_auto_invoice(){
 
-		$secure = check_ajax_referer( 'G7EZCEv3tA', 'sec_nonce', false);
-
-		if ($secure) {
-
-			$order_id = $_POST['order_id'];
-			$orders_auto_invoice_errors = get_option('wmbr_auto_invoice_errors', array());
-
-			if ( is_array($orders_auto_invoice_errors) ) {
-				if ( !array_key_exists($order_id, $orders_auto_invoice_errors) ) return false;
-
-				unset($orders_auto_invoice_errors[$order_id]);
-				update_option( 'wmbr_auto_invoice_errors', $orders_auto_invoice_errors );
-			}
-
-			echo json_encode(array('success' => true));
-
+		// Security: Check proper nonce and capabilities
+		if ( ! check_ajax_referer( 'wmbr_remove_order_invoice_nonce_' . get_current_user_id(), 'sec_nonce', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed', 'woocommerce' ) ), 403 );
+			wp_die();
+		}
+		
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'woocommerce' ) ), 403 );
+			wp_die();
 		}
 
-		die();
+		$order_id = isset($_POST['order_id']) ? absint($_POST['order_id']) : 0;
+		$orders_auto_invoice_errors = get_option('wmbr_auto_invoice_errors', array());
+
+		if ( is_array($orders_auto_invoice_errors) ) {
+			if ( !array_key_exists($order_id, $orders_auto_invoice_errors) ) {
+				wp_send_json_error( array( 'message' => 'Order not found' ), 404 );
+				wp_die();
+			}
+
+			unset($orders_auto_invoice_errors[$order_id]);
+			update_option( 'wmbr_auto_invoice_errors', $orders_auto_invoice_errors );
+		}
+
+		wp_send_json_success( array( 'message' => 'Order removed successfully' ) );
+		wp_die();
 
 	}
 
@@ -2544,15 +2718,27 @@ jQuery(document).ready(function($) {
 	 */
 	function nfe_callback(){
 
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_GET['order_key'] && $_GET['order_id']) {
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_GET['order_key']) && isset($_GET['order_id'])) {
 
-			$nfe_data = json_decode(stripslashes($_POST['data']), true);
+			// Security: Validate and sanitize inputs
+			$raw_data = isset($_POST['data']) ? wp_unslash($_POST['data']) : '';
+			if (strlen($raw_data) > 5000) { // Limit data size
+				header( 'HTTP/1.1 413 Request Entity Too Large' );
+				exit;
+			}
+			
+			$nfe_data = json_decode($raw_data, true);
+			if (json_last_error() !== JSON_ERROR_NONE || !is_array($nfe_data) || !isset($nfe_data['ID'])) {
+				header( 'HTTP/1.1 400 Bad Request' );
+				exit;
+			}
+			
 			$nfe_order_id = (int) $nfe_data['ID'];
-			$order_key = esc_attr($_GET['order_key']);
+			$order_key = sanitize_text_field($_GET['order_key']);
 			$order_id = (int) $_GET['order_id'];
 			$order = wc_get_order($order_id);
 
-			if ($order->get_order_key() != $order_key || $nfe_order_id != $order_id || ! $order) {
+			if (!$order || $order->get_order_key() !== $order_key || $nfe_order_id !== $order_id) {
 				header( 'HTTP/1.1 401 Unauthorized' );
 				exit;
 			}
@@ -2564,11 +2750,11 @@ jQuery(document).ready(function($) {
 
 				foreach($order_nfe_data as $key => $order_nfe){
 					$current_status = $order_nfe['status'];
-					$received_status = $_POST['status'];
-					if($order_nfe['uuid'] == $_POST['uuid'] && $current_status != $received_status) {
+					$received_status = isset($_POST['status']) ? sanitize_text_field($_POST['status']) : '';
+					if($order_nfe['uuid'] == ($_POST['uuid'] ?? '') && $current_status != $received_status) {
 						$order_nfe_data[$key]['status'] = $received_status;
 					}
-					if ( $order_nfe['uuid'] == $_POST['uuid'] ) {
+					if ( $order_nfe['uuid'] == ($_POST['uuid'] ?? '') ) {
 						$is_new = false;
 					}
 				}
@@ -2581,17 +2767,17 @@ jQuery(document).ready(function($) {
 
 			if ( $is_new ) {
 				$order_nfe_data[] = array(
-					'uuid'   => (string) $_POST['uuid'],
-					'status' => (string) $_POST['status'],
+					'uuid'   => (string) sanitize_text_field($_POST['uuid'] ?? ''),
+					'status' => (string) sanitize_text_field($_POST['status'] ?? ''),
 					'modelo' => 'nfe',
-					'chave_acesso' => (string) $_POST['chave'],
-					'n_recibo' => (int) isset($_POST['recibo']) ? $_POST['recibo'] : '',
-					'n_nfe' => (int) $_POST['nfe'],
-					'n_serie' => (int) $_POST['serie'],
-					'url_xml' => (string) $_POST['xml'],
-					'url_danfe' => (string) $_POST['danfe'],
-					'url_danfe_simplificada' => (string) $_POST['danfe_simples'],
-					'url_danfe_etiqueta' => (string) $_POST['danfe_etiqueta'],
+					'chave_acesso' => (string) sanitize_text_field($_POST['chave'] ?? ''),
+					'n_recibo' => (int) ($_POST['recibo'] ?? ''),
+					'n_nfe' => (int) ($_POST['nfe'] ?? 0),
+					'n_serie' => (int) ($_POST['serie'] ?? 0),
+					'url_xml' => (string) esc_url_raw($_POST['xml'] ?? ''),
+					'url_danfe' => (string) esc_url_raw($_POST['danfe'] ?? ''),
+					'url_danfe_simplificada' => (string) esc_url_raw($_POST['danfe_simples'] ?? ''),
+					'url_danfe_etiqueta' => (string) esc_url_raw($_POST['danfe_etiqueta'] ?? ''),
 					'data' => date_i18n('d/m/Y'),
 				);
 			}
@@ -2610,14 +2796,22 @@ jQuery(document).ready(function($) {
 	 */
 	function nfse_callback(){
 
-		if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_GET['order_key'] && $_GET['order_id']) {
+		if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_GET['order_key']) && isset($_GET['order_id'])) {
 
-			$order_key = esc_attr($_GET['order_key']);
+			$order_key = sanitize_text_field($_GET['order_key']);
 			$order_id = (int) $_GET['order_id'];
 			$order = wc_get_order($order_id);
-			$response = json_decode(file_get_contents("php://input"));
+			
+			// Security: Validate and sanitize input data
+			$raw_input = file_get_contents("php://input");
+			if (strlen($raw_input) > 10000) { // Limit input size
+				header( 'HTTP/1.1 413 Request Entity Too Large' );
+				exit;
+			}
+			
+			$response = json_decode($raw_input);
 
-			if (!$order || $order->get_order_key() != $order_key || !$response) {
+			if (!$order || $order->get_order_key() !== $order_key || !$response || json_last_error() !== JSON_ERROR_NONE) {
 				header( 'HTTP/1.1 401 Unauthorized' );
 				exit;
 			}
@@ -2775,33 +2969,6 @@ jQuery(document).ready(function($) {
 	}
 
 	/**
-	 * Display Messages
-	 *
-	 * @return void
-	 */
-	function display_messages(){
-
-		if (get_option('woocommercenfe_error_messages')){
-			?>
-			<div class="error">
-				<?php foreach (get_option('woocommercenfe_error_messages') as $message) { echo '<p>'.$message.'</p>'; } ?>
-			</div>
-			<?php
-			delete_option('woocommercenfe_error_messages');
-		}
-
-		if (get_option('woocommercenfe_success_messages')){
-			?>
-			<div class="updated notice notice-success">
-				<?php foreach (get_option('woocommercenfe_success_messages') as $message) { echo '<p>'.$message.'</p>'; } ?>
-			</div>
-			<?php
-			delete_option('woocommercenfe_success_messages');
-		}
-
-	}
-
-	/**
 	 * Certificate A1 validate
 	 *
 	 * @return void
@@ -2927,12 +3094,12 @@ jQuery(document).ready(function($) {
 		if ($plugins_list && count($plugins_list) > 0){
 			foreach ( $plugins_list as $plugin_path => $plugin_name ) {
 
-				if ( self::wmbr_is_plugin_active($plugin_path) ) {
+									if ( self::wmbr_is_plugin_active($plugin_path) ) {
 	
-					echo '<div class="error">
-							<p>O plugin <b>'.$plugin_name.'</b> não possui compatibilidade com os plugins <b>WooCommerce</b> e <b>Nota Fiscal Eletrônica WooCommerce</b>.</p>
-							<p>Por favor, desative-o para prosseguir com as emissões de Nota Fiscal.</p>
-						</div>';
+						echo '<div class="notice notice-error is-dismissible">
+								<p>O plugin <b>'.esc_html($plugin_name).'</b> não possui compatibilidade com os plugins <b>WooCommerce</b> e <b>Nota Fiscal Eletrônica WooCommerce</b>.</p>
+								<p>Por favor, desative-o para prosseguir com as emissões de Nota Fiscal.</p>
+							</div>';
 	
 				}
 	
@@ -2942,13 +3109,24 @@ jQuery(document).ready(function($) {
 
 	}
 
-	/**
+		/**
 	 * Function to handle ajax requisistion
 	 * to force digital certificate update
 	 *
 	 * @return void
-	**/
+	 **/
 	public function ajax_force_certificate_update() {
+
+		// Security: Verify nonce
+		if ( ! check_ajax_referer( 'woocommerce_nfe_ajax', 'security', false ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed', 'woocommerce' ) ), 403 );
+			wp_die();
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'woocommerce' ) ), 403 );
+			wp_die();
+		}
 
 		echo $this->validate_certificate( true, true );
 		die();
@@ -3013,6 +3191,9 @@ jQuery(document).ready(function($) {
 	**/
 	function api_customer_response( $customer_data, $customer, $fields, $server ) {
 
+		// Vars
+		$format = new WooCommerceNFeFormat;
+
         // Billing fields.
 		$customer_data['billing_address']['persontype']   = $this->get_person_type( $customer->billing_persontype );
 		$customer_data['billing_address']['cpf']          = $format->format_number( $customer->billing_cpf );
@@ -3022,7 +3203,7 @@ jQuery(document).ready(function($) {
 		$customer_data['billing_address']['sex']          = substr( $customer->billing_sex, 0, 1 );
 		$customer_data['billing_address']['number']       = $customer->billing_number;
 		$customer_data['billing_address']['neighborhood'] = $customer->billing_neighborhood;
-		$customer_data['billing_address']['cellphone']    = str_replace("?", "", $order->billing_cellphone);
+		$customer_data['billing_address']['cellphone']    = str_replace("?", "", $customer->billing_cellphone);
 
 		// Shipping fields.
 		$customer_data['shipping_address']['number']       = $customer->shipping_number;
@@ -3066,9 +3247,11 @@ jQuery(document).ready(function($) {
 	 */
 	function save_ncm_field_product_variation( $variation_id, $i ) {
 		
-		// remover 
-		$ncm = $_POST['variable_ncm'][$i];
-		update_post_meta( $variation_id, 'variable_ncm', $ncm );
+		// Security: Sanitize input
+		if ( isset($_POST['variable_ncm'][$i]) ) {
+			$ncm = sanitize_text_field( $_POST['variable_ncm'][$i] );
+			update_post_meta( $variation_id, 'variable_ncm', $ncm );
+		}
 
 	}
 
@@ -3077,74 +3260,72 @@ jQuery(document).ready(function($) {
 	 * 
 	 * @return void
 	 */
-	function get_order_cpf_cnpj($post_id, $order_nfe) {
+	function get_order_cpf_cnpj($order, $order_nfe) {
 
-		if (!$post_id) return;
+		if (!$order) return;
 
+		// Get data
 		$nfe_doc = get_transient('cached_nfe_doc_'.$order_nfe['uuid']);
-		$cpf = get_post_meta($post_id, '_billing_cpf', true);
-		$cnpj = get_post_meta($post_id, '_billing_cnpj', true);
-		$person_type = get_post_meta($post_id, '_billing_persontype', true);
+		$cpf = $order->get_meta('_billing_cpf');
+		$cnpj = $order->get_meta('_billing_cnpj');
+		$person_type = $order->get_meta('_billing_persontype');
 		$post_doc = ($person_type == '1') ? ($cpf ?: '') : ($cnpj ?: '');
-		$nfe = get_post_meta($post_id, 'nfe', true);
-		$order_doc = false;
+		$nfes = $order->get_meta('nfe');
 
-		if ( !empty($nfe) && is_array($nfe)) {
-			foreach ($nfe as $item) {
-				$nfe_doc = isset($item['nfe_doc']) ? $item['nfe_doc'] : null;
-				if ($nfe_doc != $post_doc) $order_doc = true;
-			}
+		// Returns if found in cache
+		if (!empty($nfe_doc)) {
+			return $nfe_doc;
 		}
 
-		if ( empty($nfe_doc) || $order_doc == true ){
-			
-			$print = new WooCommerceNFePrint;
-			if (!empty($order_nfe['url_xml'])) {
-				$return = $print->curl_get_file_contents($order_nfe['url_xml']);
-			} else {
-				return;
-			}
-			$sxml = simplexml_load_string($return);
-			$sxml = json_encode($sxml, JSON_PRETTY_PRINT);
-			$json = json_decode(str_replace('@attributes', 'attributes', $sxml));
-			$doc = null;
+		// Returns whether the document was generated during the invoice issuance
+		if (!empty($order_nfe['nfe_doc'])) {
+			return $order_nfe['nfe_doc'];
+		}
 
-			if (isset($order_nfe['modelo']) && in_array($order_nfe['modelo'], ['nfse', 'lote_rps'])) {
-				$searchTag = ['IdentificacaoTomador'];	
-				$tomador = $this->searchKeyInJson($json, $searchTag);
-				$tomDoc = $this->searchKeyInJson($tomador, [], true);
-				$doc = implode('',$tomDoc);
-			} else {
-				if ($order_nfe['status'] == 'reprovado') {
-					$doc = isset($json->infNFe->dest) ? ($json->infNFe->dest->CPF ?? $json->infNFe->dest->CNPJ) : null;
-				} else {
-					$doc = isset($json->infNFe->dest) 
-					? ($json->infNFe->dest->CPF ?? $json->infNFe->dest->CNPJ)
-					: ($json->NFe->infNFe->dest->CPF ?? $json->NFe->infNFe->dest->CNPJ ?? null);
+		// Returns the checkout document if the XML URL does not exist.
+		if (empty($order_nfe['url_xml'])) {
+			return $post_doc;
+		}
+
+		// Searches for the document in the XML
+		$print = new WooCommerceNFePrint;
+		$return = $print->curl_get_file_contents($order_nfe['url_xml']);
+		$sxml = simplexml_load_string($return);
+		$sxml = json_encode($sxml, JSON_PRETTY_PRINT);
+		$json = json_decode(str_replace('@attributes', 'attributes', $sxml));
+
+		// Returns the checkout document if the API response is not a valid XML.
+		if (empty($json)) {
+			return $post_doc;
+		}
+
+		$doc = null;
+
+		if (isset($order_nfe['modelo']) && in_array($order_nfe['modelo'], ['nfse', 'lote_rps'])) {
+			$searchTag = ['IdentificacaoTomador'];	
+			$tomador = $this->searchKeyInJson($json, $searchTag);
+			$tomDoc = $this->searchKeyInJson($tomador, [], true);
+			$doc = implode('',$tomDoc);
+		} else {
+			$doc = $json->NFe->infNFe->dest->CPF ?? $json->NFe->infNFe->dest->CNPJ ?? $json->infNFe->dest->CPF ?? $json->infNFe->dest->CNPJ ?? null;
+		}
+
+		// Returns the checkout document if the CPF/CNPJ is not found in the XML.
+		if (empty($doc)) {
+			return $post_doc;
+		}
+
+		if (!empty($nfes) && is_array($nfes)) {
+			foreach($nfes as $key => $nfe) {
+				if (!empty($nfe['uuid']) && !empty($order_nfe['uuid']) && $nfe['uuid'] == $order_nfe['uuid']) {
+					$nfes[$key]['nfe_doc'] = str_replace(['.', '-', '/'], '', $doc);
 				}
 			}
-
-			if (empty($doc)) {
-				$reason = __( "<strong>[WebmaniaBR® Nota Fiscal] Erro:</strong> Não foi possível gerar o Token para uma ou mais emissões deste pedido. Acesso restrito - Token (E1.3)");
-				$this->add_error($reason);
-				return;
-
-			} else {
-
-				!is_array($nfe) ? $nfe = array() ?: isset($nfe[0]) : $nfe[0] = array();
-				
-				$nfe_doc  = $doc;
-
-				set_transient( 'cached_nfe_doc_'.$order_nfe['uuid'], $nfe_doc, 24 * HOUR_IN_SECONDS );
-
-				return $nfe_doc;
-			}
-
-		} else {
-			
-			return $nfe_doc;
-
 		}
+
+		$order->update_meta_data('nfe', $nfes);
+		$order->save();
+		set_transient( 'cached_nfe_doc_'.$order_nfe['uuid'], $doc, 24 * HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/class-frontend.php
+++ b/class-frontend.php
@@ -83,13 +83,18 @@ class WooCommerceNFeFrontend extends WooCommerceNFe {
         $cep = get_option('wc_settings_woocommercenfe_cep');
       }
 
-      wp_register_script( 'woocommercenfe_maskedinput', '//cdnjs.cloudflare.com/ajax/libs/jquery.maskedinput/1.4.1/jquery.maskedinput.js', array('jquery'), $version, true );
+      // Security: Use HTTPS for external resources
+      wp_register_script( 'woocommercenfe_maskedinput', 'https://cdnjs.cloudflare.com/ajax/libs/jquery.maskedinput/1.4.1/jquery.maskedinput.js', array('jquery'), $version, true );
       wp_register_script( 'woocommercenfe_correios', apply_filters( 'woocommercenfe_plugins_url', plugins_url( 'assets/js/correios.min.js', __FILE__ ) ), array('jquery'), $version, true );
       wp_register_script( 'woocommercenfe_scripts', apply_filters( 'woocommercenfe_plugins_url', plugins_url( 'assets/js/scripts.js', __FILE__ ) ), array('jquery'), $version, true );
 
+      // Security: Ensure boolean values
       if ($mascara_campos == 'yes') $array['maskedinput'] = 1;
       if ($cep == 'yes') $array['cep'] = 1;
       if ($tipo_pessoa == 'yes') $array['person_type'] = 1;
+      
+      // Security: Add nonce for AJAX calls
+      $array['ajax_nonce'] = wp_create_nonce('woocommerce_nfe_ajax');
 
       if ($mascara_campos == 'yes') wp_enqueue_script( 'woocommercenfe_maskedinput' );
       if ($cep == 'yes') wp_enqueue_script( 'woocommercenfe_correios' );
@@ -307,19 +312,38 @@ class WooCommerceNFeFrontend extends WooCommerceNFe {
 
   function validate_checkout_fields(){
 
-    $billing_persontype = isset( $_POST['billing_persontype'] ) ? $_POST['billing_persontype'] : 0;
+    // Security: Verify nonce
+    if ( ! isset( $_POST['woocommerce-process-checkout-nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce-process-checkout-nonce'], 'woocommerce-process_checkout' ) ) {
+      return;
+    }
+
+    // Security: Sanitize and validate inputs
+    $billing_persontype = isset( $_POST['billing_persontype'] ) ? sanitize_text_field( $_POST['billing_persontype'] ) : 0;
+    $billing_persontype = intval( $billing_persontype );
 
     if ($billing_persontype == 1){
 
-      if (empty( $_POST['billing_cpf'] )){
+      $billing_cpf = isset( $_POST['billing_cpf'] ) ? sanitize_text_field( $_POST['billing_cpf'] ) : '';
 
-          wc_add_notice( sprintf( '<strong>%s</strong> %s.', __( 'CPF', $domain ), __( 'é um campo obrigatório', $domain ) ), 'error' );
+      if (empty( $billing_cpf )){
+
+          wc_add_notice( sprintf( '<strong>%s</strong> %s.', esc_html__( 'CPF', $this->domain ), esc_html__( 'é um campo obrigatório', $this->domain ) ), 'error' );
 
       }
 
-      if (!empty( $_POST['billing_cpf'] ) && !WooCommerceNFeFormat::is_cpf( $_POST['billing_cpf'] )){
+      if (!empty( $billing_cpf ) && !WooCommerceNFeFormat::is_cpf( $billing_cpf )){
 
-          wc_add_notice( sprintf( '<strong>%s</strong> %s.', __( 'CPF', $domain ), __( 'informado não é válido', $domain ) ), 'error' );
+          // Security: Use esc_html for all outputs
+          wc_add_notice( 
+            wp_kses( 
+              sprintf( '<strong>%s</strong> %s.', 
+                esc_html__( 'CPF', $this->domain ), 
+                esc_html__( 'informado não é válido', $this->domain ) 
+              ),
+              array( 'strong' => array() )
+            ), 
+            'error' 
+          );
 
       }
 
@@ -327,21 +351,34 @@ class WooCommerceNFeFrontend extends WooCommerceNFe {
 
     if ($billing_persontype == 2){
 
-      if (empty( $_POST['billing_cnpj'] )){
+      $billing_cnpj = isset( $_POST['billing_cnpj'] ) ? sanitize_text_field( $_POST['billing_cnpj'] ) : '';
+      $billing_company = isset( $_POST['billing_company'] ) ? sanitize_text_field( $_POST['billing_company'] ) : '';
 
-          wc_add_notice( sprintf( '<strong>%s</strong> %s.', __( 'CNPJ', $domain ), __( 'é um campo obrigatório', $domain ) ), 'error' );
+      if (empty( $billing_cnpj )){
 
-      }
-
-      if (empty( $_POST['billing_company'] )){
-
-          wc_add_notice( sprintf( '<strong>%s</strong> %s.', __( 'Razão Social', $domain ), __( 'é um campo obrigatório', $domain ) ), 'error' );
+          wc_add_notice( sprintf( '<strong>%s</strong> %s.', esc_html__( 'CNPJ', $this->domain ), esc_html__( 'é um campo obrigatório', $this->domain ) ), 'error' );
 
       }
 
-      if (!empty( $_POST['billing_cnpj'] ) && !WooCommerceNFeFormat::is_cnpj( $_POST['billing_cnpj'] )){
+      if (empty( $billing_company )){
 
-          wc_add_notice( sprintf( '<strong>%s</strong> %s.', __( 'CNPJ', $domain ), __( 'informado não é válido', $domain ) ), 'error' );
+          wc_add_notice( sprintf( '<strong>%s</strong> %s.', esc_html__( 'Razão Social', $this->domain ), esc_html__( 'é um campo obrigatório', $this->domain ) ), 'error' );
+
+      }
+
+      if (!empty( $billing_cnpj ) && !WooCommerceNFeFormat::is_cnpj( $billing_cnpj )){
+
+          // Security: Use wp_kses for safe HTML output
+          wc_add_notice( 
+            wp_kses( 
+              sprintf( '<strong>%s</strong> %s.', 
+                esc_html__( 'CNPJ', $this->domain ), 
+                esc_html__( 'informado não é válido', $this->domain ) 
+              ),
+              array( 'strong' => array() )
+            ), 
+            'error' 
+          );
 
       }
 
@@ -351,12 +388,20 @@ class WooCommerceNFeFrontend extends WooCommerceNFe {
 
   function validate_checkout_fields_with_plugin(){
 
+    // Security: Verify nonce
+    if ( ! isset( $_POST['woocommerce-process-checkout-nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce-process-checkout-nonce'], 'woocommerce-process_checkout' ) ) {
+      return;
+    }
+
     $domain = '';
     $bairro = get_option('wc_settings_woocommercenfe_bairro');
+    
+    // Security: Sanitize input
+    $billing_neighborhood = isset( $_POST['billing_neighborhood'] ) ? sanitize_text_field( $_POST['billing_neighborhood'] ) : '';
 
-    if ($bairro == 'yes' && empty( $_POST['billing_neighborhood'] )){
+    if ($bairro == 'yes' && empty( $billing_neighborhood )){
 
-      wc_add_notice( sprintf( '<strong>%s</strong> %s.', __( 'Bairro', $domain ), __( 'é um campo obrigatório', $domain ) ), 'error' );
+      wc_add_notice( sprintf( '<strong>%s</strong> %s.', esc_html__( 'Bairro', $domain ), esc_html__( 'é um campo obrigatório', $domain ) ), 'error' );
 
     }
 

--- a/class-issue.php
+++ b/class-issue.php
@@ -17,8 +17,11 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 		$result = array();
 
-		if (isset($_POST['save']) && $_POST['save'] === 'Update') {
-			$this->add_error("<strong>[WebmaniaBR® Nota Fiscal] Aviso: </strong> Para relizar esta emissão utilize o botão <strong>'Aplicar'</strong> localizado ao lado da lista de ações do pedido.");return;
+		// Security: Sanitize and validate POST inputs
+		$save_action = isset($_POST['save']) ? sanitize_text_field($_POST['save']) : '';
+		if ($save_action === 'Update') {
+			$this->add_error("<strong>[WebmaniaBR® Nota Fiscal] Aviso: </strong> Para relizar esta emissão utilize o botão <strong>'Aplicar'</strong> localizado ao lado da lista de ações do pedido.");
+			return;
 		}
 
 		foreach ($order_ids as $order_id) {
@@ -59,27 +62,53 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 					$mensagem = 'Erro ao emitir a NF-e do Pedido #'.$order_id.':';
 					$mensagem .= '<ul style="padding-left:20px;">';
-					$mensagem .= '<li>'.$response->error.'</li>';
-	
-					if (isset($response->log)){
-						if ($response->log->xMotivo){
-							if(isset($response->log->aProt[0]->xMotivo)){
-								$error = $response->log->aProt[0]->xMotivo;
-							}else{
-								$error = $response->log->xMotivo;
+
+					$primary_error_message = '';
+					if ( isset( $response->error ) && is_string( $response->error ) ) {
+						$primary_error_message = sanitize_text_field( $response->error );
+						if ( '' !== $primary_error_message ) {
+							$mensagem .= '<li>' . esc_html( $primary_error_message ) . '</li>';
+						}
+					}
+
+					$error_messages = array();
+					if ( ! empty( $response->motivo ) && is_string( $response->motivo ) ) {
+						$error_messages[] = sanitize_text_field( $response->motivo );
+					} elseif ( isset( $response->log ) ) {
+						if ( ! empty( $response->log->xMotivo ) ) {
+							if ( ! empty( $response->log->aProt[0]->xMotivo ) && is_string( $response->log->aProt[0]->xMotivo ) ) {
+								$error_messages[] = sanitize_text_field( $response->log->aProt[0]->xMotivo );
+							} elseif ( is_string( $response->log->xMotivo ) ) {
+								$error_messages[] = sanitize_text_field( $response->log->xMotivo );
 							}
-							$mensagem .= '<li>'.$error.'</li>';
 						} else {
-							foreach ($response->log as $erros){
-								foreach ($erros as $erro) {
-									$mensagem .= '<li>'.$erro.'</li>';
+							foreach ( $response->log as $item ) {
+								if ( is_string( $item ) ) {
+									$error_messages[] = sanitize_text_field( $item );
 								}
 							}
 						}
 					}
+
+					$error_messages = array_values( array_unique( array_filter( $error_messages ) ) );
+
+					foreach ( $error_messages as $error_message_text ) {
+						$mensagem .= '<li>' . esc_html( $error_message_text ) . '</li>';
+					}
+
+					$invoice_error = $primary_error_message;
+					if ( '' === $invoice_error && ! empty( $error_messages ) ) {
+						$invoice_error = reset( $error_messages );
+					}
+
+					if ( '' === $invoice_error && empty( $error_messages ) ) {
+						$fallback_error = __( 'Erro desconhecido.', $this->domain );
+						$invoice_error = sanitize_text_field( $fallback_error );
+						$mensagem .= '<li>' . esc_html( $invoice_error ) . '</li>';
+					}
+
 					$mensagem .= '</ul>';
-	
-					$invoice_error = isset($response->error) ? $response->error : $error;
+
 					$is_auto_invoice && $this->send_error_email( $mensagem, $order_id );
 					$this->add_id_to_invoice_errors( $invoice_error, $order_id );
 					$this->add_error( $mensagem );
@@ -94,7 +123,10 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 	
 						if ( is_object($response) && isset($data['nfe']['previa_danfe']) ) {
 	
-							$this->add_success( 'Pré-visualizar Danfe: <a href="'.$response->danfe.'" target="_blank">'.$response->danfe.'</a>' );
+							// Security: Validate URL before output
+							if (filter_var($response->danfe, FILTER_VALIDATE_URL)) {
+								$this->add_success( 'Pré-visualizar Danfe: <a href="'.esc_url($response->danfe).'" target="_blank" rel="noopener noreferrer">'.esc_html($response->danfe).'</a>' );
+							}
 	
 						} else {
 	
@@ -110,7 +142,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 				// If API respond with status, register 'NF-e'
 				if ( is_object($response) && $response->status ) {
 
-					$nfe = get_post_meta( $order->id, 'nfe', true );
+					$nfe = $order->get_meta('nfe');
 					$nfe_doc = $data['nfe']['cliente']['cpf'] ?? $data['nfe']['cliente']['cnpj'];
 					$nfe_doc = str_replace(['.', '-', '/'], '', $nfe_doc);
 	
@@ -176,24 +208,62 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 				if (isset($response->error) || isset($response->errors) || $response->status == 'reprovado') {
 
-					$error_message = $response->error;
-					if (!$error_message) {
-						$error_message = (array) $response->errors;
-						if (!empty($error_message)) $error_message = reset($error_message);
-					}
-					if (!$error_message) $error_message = $response->motivo;
 					$mensagem = 'Erro ao emitir a NFS-e do Pedido #'.$order_id.':';
 					$mensagem .= '<ul style="padding-left:20px;">';
-					if (is_array($error_message)) {
-						foreach ($error_message as $error_message_item) $mensagem .= '<li>'.$error_message_item.'</li>';
+
+					$error_sources = array();
+					if ( ! empty( $response->error ) ) {
+						$error_sources[] = $response->error;
 					}
-					else {
-						$mensagem .= '<li>'.$error_message.'</li>';
+
+					if ( empty( $error_sources ) && ! empty( $response->errors ) ) {
+						if ( is_array( $response->errors ) ) {
+							$error_sources = array_merge( $error_sources, $response->errors );
+						} else {
+							$error_sources[] = $response->errors;
+						}
 					}
+
+					if ( empty( $error_sources ) && ! empty( $response->motivo ) ) {
+						$error_sources[] = $response->motivo;
+					}
+
+					$error_messages_nfse = array();
+					foreach ( $error_sources as $error_source ) {
+						if ( is_array( $error_source ) ) {
+							foreach ( $error_source as $error_message_item ) {
+								if ( is_scalar( $error_message_item ) || ( is_object( $error_message_item ) && method_exists( $error_message_item, '__toString' ) ) ) {
+									$sanitized_item = sanitize_text_field( (string) $error_message_item );
+									if ( '' !== $sanitized_item ) {
+										$error_messages_nfse[] = $sanitized_item;
+									}
+								}
+							}
+						} elseif ( is_scalar( $error_source ) || ( is_object( $error_source ) && method_exists( $error_source, '__toString' ) ) ) {
+							$sanitized_item = sanitize_text_field( (string) $error_source );
+							if ( '' !== $sanitized_item ) {
+								$error_messages_nfse[] = $sanitized_item;
+							}
+						}
+					}
+
+					$error_messages_nfse = array_values( array_unique( $error_messages_nfse ) );
+
+					foreach ($error_messages_nfse as $error_message_item) {
+						$mensagem .= '<li>' . esc_html( $error_message_item ) . '</li>';
+					}
+
+					if (empty( $error_messages_nfse )) {
+						$fallback_error = __( 'Erro desconhecido.', $this->domain );
+						$fallback_error = sanitize_text_field( $fallback_error );
+						$error_messages_nfse[] = $fallback_error;
+						$mensagem .= '<li>' . esc_html( $fallback_error ) . '</li>';
+					}
+
 					$mensagem .= '</ul>';
 	
 					$is_auto_invoice && $this->send_error_email( $mensagem, $order_id );
-					$this->add_id_to_invoice_errors( (is_array($error_message) ? implode(' | ', $error_message) : $error_message), $order_id );
+					$this->add_id_to_invoice_errors( implode(' | ', $error_messages_nfse ), $order_id );
 					$this->add_error( $mensagem );
 	
 				} else {
@@ -214,7 +284,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 				// If API respond with status, register 'NFS-e'
 				if ( is_object($response) && $response->status ) {
 	
-					$nfe = get_post_meta( $order->id, 'nfe', true );
+					$nfe = $order->get_meta('nfe');
 	
 					if (!$nfe)
 						$nfe = array();
@@ -335,7 +405,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 		}
 
 		// Order
-		$modalidade_frete = isset($_POST['modalidade_frete'])? $_POST['modalidade_frete']: $order->get_meta( '_nfe_modalidade_frete' );
+		$modalidade_frete = isset($_POST['modalidade_frete'])? sanitize_text_field($_POST['modalidade_frete']) : $order->get_meta( '_nfe_modalidade_frete' );
 
 		if (!$modalidade_frete || $modalidade_frete == 'null')
 			 $modalidade_frete = 0;
@@ -345,8 +415,10 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 		// Order Operation
 		$natureza_operacao = ($order->get_meta( '_nfe_natureza_operacao_pedido' )) ? $order->get_meta( '_nfe_natureza_operacao_pedido' ) : get_option('wc_settings_woocommercenfe_natureza_operacao');
 
-		if ( isset($_POST['natureza_operacao_pedido']) && $_POST['natureza_operacao_pedido'] != '' && $_POST['natureza_operacao_pedido'] != $natureza_operacao ) {
-			$natureza_operacao = $_POST['natureza_operacao_pedido'];
+		// Security: Sanitize POST input
+		$post_natureza_operacao = isset($_POST['natureza_operacao_pedido']) ? sanitize_text_field($_POST['natureza_operacao_pedido']) : '';
+		if ( $post_natureza_operacao !== '' && $post_natureza_operacao !== $natureza_operacao ) {
+			$natureza_operacao = $post_natureza_operacao;
 		}
 
 		// Init data
@@ -358,7 +430,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 			'natureza_operacao' => apply_filters( 'nfe_order_operation_n', $natureza_operacao, $post_id  ), // Natureza da Operação
 			'modelo'            => apply_filters( 'nfe_order_model', 1, $post_id ), // Modelo da Nota Fiscal (NF-e ou NFC-e)
 			'finalidade'        => apply_filters( 'nfe_order_finality', 1, $post_id ), // Finalidade de emissão da Nota Fiscal
-			'ambiente'          => apply_filters( 'nfe_environment', ( isset($_POST['emitir_homologacao']) && $_POST['emitir_homologacao'] ? '2' : (int) get_option('wc_settings_woocommercenfe_ambiente') ), $post_id ) // Identificação do Ambiente do Sefaz
+			'ambiente'          => apply_filters( 'nfe_environment', ( isset($_POST['emitir_homologacao']) && sanitize_text_field($_POST['emitir_homologacao']) ? '2' : (int) get_option('wc_settings_woocommercenfe_ambiente') ), $post_id ) // Identificação do Ambiente do Sefaz
 		);
 
 		// Fees
@@ -403,11 +475,11 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 		);
 
 		//Intermediador da operação
-		$intermediador = $_POST['nfe_info_intermediador'] ?? $order->get_meta( '_nfe_info_intermediador' ) ?? '';
+		$intermediador = isset($_POST['nfe_info_intermediador']) ? sanitize_text_field($_POST['nfe_info_intermediador']) : $order->get_meta( '_nfe_info_intermediador' );
 		if ($intermediador) {
-			$data['pedido']['intermediador'] = (!empty($_POST)) ? $_POST['nfe_info_intermediador_type'] : $order->get_meta( '_nfe_info_intermediador_type' );
-			$data['pedido']['cnpj_intermediador'] = (!empty($_POST)) ? $_POST['nfe_info_intermediador_cnpj'] : $order->get_meta( '_nfe_info_intermediador_cnpj' );
-			$data['pedido']['id_intermediador'] = (!empty($_POST)) ? $_POST['nfe_info_intermediador_id'] : $order->get_meta( '_nfe_info_intermediador_id' );
+			$data['pedido']['intermediador'] = isset($_POST['nfe_info_intermediador_type']) ? sanitize_text_field($_POST['nfe_info_intermediador_type']) : $order->get_meta( '_nfe_info_intermediador_type' );
+			$data['pedido']['cnpj_intermediador'] = isset($_POST['nfe_info_intermediador_cnpj']) ? sanitize_text_field($_POST['nfe_info_intermediador_cnpj']) : $order->get_meta( '_nfe_info_intermediador_cnpj' );
+			$data['pedido']['id_intermediador'] = isset($_POST['nfe_info_intermediador_id']) ? sanitize_text_field($_POST['nfe_info_intermediador_id']) : $order->get_meta( '_nfe_info_intermediador_id' );
 		}
 		else {
 			$data['pedido']['intermediador'] = get_option('wc_settings_woocommercenfe_intermediador');
@@ -450,7 +522,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 			$consumidor_inf .= $fee_aditional_informations;
 		}
 		if ($additional_info = (!empty($_POST) && isset($_POST['nfe_additional_info'])) ? $_POST['nfe_additional_info'] : $order->get_meta( '_nfe_additional_info' )) {
-			$value = $_POST['nfe_additional_info_text'];
+			$value = isset($_POST['nfe_additional_info_text']) ? sanitize_text_field($_POST['nfe_additional_info_text']) : '';
 
 			if (!isset($value)) {
 				$value = $order->get_meta( '_nfe_additional_info_text' );
@@ -489,8 +561,8 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 		}
 
 		// Contribuinte ICMS
-		$contribuinte = (!empty($_POST) && isset($_POST['nfe_contribuinte'])) ? $_POST['nfe_contribuinte'] : $order->get_meta( '_nfe_contribuinte' );
-		if (in_array($contribuinte, [1, 2, 9])) {
+		$contribuinte = isset($_POST['nfe_contribuinte']) ? intval($_POST['nfe_contribuinte']) : intval($order->get_meta( '_nfe_contribuinte' ));
+		if (in_array($contribuinte, [1, 2, 9], true)) {
 			$data['cliente']['contribuinte'] = $contribuinte;
 		}
 
@@ -539,7 +611,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 			}
 
 			$product_info = $this->get_product_nfe_info($item, $order);
-			$ignore_product = apply_filters( 'nfe_order_product_ignore', $order->get_meta( '_nfe_ignorar_nfe' ), $product_id, $post_id);
+			$ignore_product = apply_filters( 'nfe_order_product_ignore', $product->get_meta( '_nfe_ignorar_nfe' ), $product_id, $post_id);
 
 			// Ignore product or NOT
 			if ($ignore_product == 1){
@@ -568,7 +640,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 			$beneficio_fiscal = $order->get_meta( '_nfe_beneficio_fiscal_pedido' );
 
 			if ( isset($_POST['beneficio_fiscal_pedido']) && $_POST['beneficio_fiscal_pedido'] != '' && $_POST['beneficio_fiscal_pedido'] != $beneficio_fiscal ) {
-				$beneficio_fiscal = $_POST['beneficio_fiscal_pedido'];
+				$beneficio_fiscal = sanitize_text_field($_POST['beneficio_fiscal_pedido']);
 			}
 
 			if ($beneficio_fiscal){
@@ -655,7 +727,8 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 		}
 
 		// Product Volume and Weight
-		if ($volume_weight = (!empty($_POST) && isset($_POST['nfe_volume_weight'])) ? $_POST['nfe_volume_weight'] : $order->get_meta( '_nfe_volume_weight' )){
+		$volume_weight = isset($_POST['nfe_volume_weight']) ? (bool) $_POST['nfe_volume_weight'] : (bool) $order->get_meta( '_nfe_volume_weight' );
+		if ($volume_weight) {
 
 			$order_specifics = array(
 				'volume' => '_nfe_transporte_volume',
@@ -666,7 +739,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 			foreach ($order_specifics as $api_key => $meta_key) {
 
-				$value = $_POST[str_replace('_nfe_', '', $meta_key)];
+				$value = isset($_POST[str_replace('_nfe_', '', $meta_key)]) ? sanitize_text_field($_POST[str_replace('_nfe_', '', $meta_key)]) : '';
 
 				if (!isset($value))
 					$value = $order->get_meta( $meta_key );
@@ -791,8 +864,9 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 	
 				// Service additional information
 				$servico_inf = get_option('wc_settings_woocommercenfe_servico_inf');
-				if ($service_info = (!empty($_POST) && isset($_POST['nfe_service_info'])) ? $_POST['nfe_service_info'] : $order->get_meta( '_nfe_service_info' )) {
-					$value = $_POST['nfe_service_info_text'];
+				$service_info = isset($_POST['nfe_service_info']) ? (bool) $_POST['nfe_service_info'] : (bool) $order->get_meta( '_nfe_service_info' );
+				if ($service_info) {
+					$value = isset($_POST['nfe_service_info_text']) ? sanitize_textarea_field($_POST['nfe_service_info_text']) : '';
 
 					if (!isset($value)) {
 						$value = $order->get_meta( '_nfe_service_info_text' );
@@ -802,7 +876,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 				if (!empty($servico_inf)) $discriminacao .= ' - ' . $servico_inf;
 
 				// Discount
-				$tipo_desconto = isset($_POST['tipo_desconto']) ? $_POST['tipo_desconto'] : null;
+				$tipo_desconto = isset($_POST['tipo_desconto']) ? sanitize_text_field($_POST['tipo_desconto']) : null;
 				if (empty($tipo_desconto)) $tipo_desconto = $order->get_meta( '_nfse_tipo_desconto' );
 				if (empty($tipo_desconto)) $tipo_desconto = get_option('wc_settings_woocommercenfe_tipo_desconto_nfse');
 				if (empty($tipo_desconto)) $tipo_desconto = 1;
@@ -1250,7 +1324,7 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 		$ids_db = get_option('wmbr_auto_invoice_errors');
 		$order = wc_get_order( $order_id );
-		$nfes = get_post_meta( $order->id,  'nfe', true );
+		$nfes = $order->get_meta('nfe');
 
 		if ( !empty($nfes) && is_array($nfes) ) {
 			foreach ( $nfes as $nfe ) {

--- a/class-issue.php
+++ b/class-issue.php
@@ -366,9 +366,9 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 			foreach ($order->get_fees() as $key => $item){
 
-				if ($item['line_total'] < 0){
+				if ((float)$item['line_total'] < 0){
 
-					$discount = abs($item['line_total']);
+					$discount = abs((float)$item['line_total']);
 					$total_discount += $discount;
 
 				} else {
@@ -730,9 +730,9 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 			foreach ($order->get_fees() as $key => $item){
 
-				if ($item['line_total'] < 0){
+				if ((float)$item['line_total'] < 0){
 
-					$discount = abs($item['line_total']);
+					$discount = abs((float)$item['line_total']);
 					$total_discount += $discount;
 
 				}
@@ -1022,11 +1022,11 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 		} else if($product_type == 'mix-and-match') {
 
-			$discount = abs($total_discount);
+			$discount = abs((float)$total_discount);
 
 		} else {
 
-			$discount = abs($total_bundle - $total_products);
+			$discount = abs((float)$total_bundle - (float)$total_products);
             $discount = ($total_bundle == 0 && $total_products > 0) ? 0 : $discount;
 
 		}

--- a/class-issue.php
+++ b/class-issue.php
@@ -366,9 +366,11 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 
 			foreach ($order->get_fees() as $key => $item){
 
-				if ((float)$item['line_total'] < 0){
+				$line_total = (float)$item['line_total'];
 
-					$discount = abs((float)$item['line_total']);
+				if ($line_total < 0){
+
+					$discount = abs($line_total);
 					$total_discount += $discount;
 
 				} else {
@@ -376,8 +378,8 @@ class WooCommerceNFeIssue extends WooCommerceNFe {
 					if ( $fee_aditional_informations != '' )
 						$fee_aditional_informations .= ' / ';
 
-					$fee_aditional_informations .= $item['name'] . ': R$' . number_format($item['line_total'], 2, ',', '');
-					$fee = $item['line_total'];
+					$fee_aditional_informations .= $item['name'] . ': R$' . number_format($line_total, 2, ',', '');
+					$fee = $line_total;
 					$total_fee += $fee;
 
 				}

--- a/class-print.php
+++ b/class-print.php
@@ -49,7 +49,7 @@ class WooCommerceNFePrint extends WooCommerceNFe {
 
 			//Get order nfe data
 			$order = wc_get_order( $order_id );
-			$order_nfe_data = get_post_meta( $order->id,  'nfe', true );
+			$order_nfe_data = $order->get_meta('nfe');
 
 			if(!$order_nfe_data){
 				continue;
@@ -83,8 +83,10 @@ class WooCommerceNFePrint extends WooCommerceNFe {
 
 		if ($result["result"] == true){
 
-			$temp_dir = str_replace(ABSPATH, '', $this->files_folder);
-			$link_pdf = get_site_url().'/'.$temp_dir.'/'.$result["file"].".pdf";
+			$abs_path = str_replace(['\\', '/'], '/', ABSPATH);
+			$file_folder = str_replace(['\\', '/'], '/', $this->files_folder);
+			$temp_dir = str_replace($abs_path, '', $file_folder);
+			$link_pdf = trailingslashit(get_site_url()) . trim($temp_dir, '/') . '/' . $result["file"] . ".pdf";
 			
 			$this->add_success( "Arquivo de impressão gerado com sucesso. <a href='$link_pdf' target='_blank'>Clique aqui</a> para acessá-lo." );
 
@@ -112,12 +114,31 @@ class WooCommerceNFePrint extends WooCommerceNFe {
 		foreach ($data as $item) {
 
 			try {
+				// Security: Validate chave to prevent path traversal
+				$chave = preg_replace('/[^a-zA-Z0-9]/', '', $item['chave']);
+				if (empty($chave) || strlen($chave) > 44) {
+					continue; // Invalid NFe key format
+				}
+
+				// Security: Validate URL to prevent SSRF
+				if (!$this->validate_danfe_url($item['url'])) {
+					continue;
+				}
+
 				$content = $this->curl_get_file_contents($item['url']);
 				if ($content && (strpos($content, '%PDF-') !== false && strpos($content, '%%EOF') !== false)) {
-					file_put_contents("{$this->files_folder}/{$item['chave']}.pdf", $content);
-					$pdf->addPDF("{$this->files_folder}/{$item['chave']}.pdf", 'all');
+					$safe_filename = $this->files_folder . DIRECTORY_SEPARATOR . $chave . '.pdf';
+					
+					// Security: Additional path traversal check
+					if (strpos(realpath(dirname($safe_filename)), realpath($this->files_folder)) !== 0) {
+						continue;
+					}
+					
+					file_put_contents($safe_filename, $content);
+					$pdf->addPDF($safe_filename, 'all');
 				}
 			} catch (Exception $e) {
+				error_log('WooCommerceNFe: Error processing PDF: ' . $e->getMessage());
 				continue;
 			}
 
@@ -134,34 +155,105 @@ class WooCommerceNFePrint extends WooCommerceNFe {
 	}
 
 	/**
-	 * Get file content from URL using curl
+	 * Validate DANFE URL to prevent SSRF attacks
+	 * 
+	 * @param string $url
+	 * @return boolean
+	 */
+	private function validate_danfe_url($url) {
+		
+		// Security: Only allow WebmaniaBR domains
+		$allowed_domains = [
+			'nfe.webmaniabr.com',
+			'webmaniabr.com'
+		];
+		
+		$parsed_url = parse_url($url);
+		if (!$parsed_url || !isset($parsed_url['host'])) {
+			return false;
+		}
+		
+		// Check if domain is allowed
+		$host = strtolower($parsed_url['host']);
+		foreach ($allowed_domains as $allowed_domain) {
+			if ($host === $allowed_domain || substr($host, -strlen('.' . $allowed_domain)) === '.' . $allowed_domain) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+
+	/**
+	 * Get file content from URL using curl (secure version)
 	 * 
 	 * @param string $url
 	 * @return mixed
 	 */
 	public static function curl_get_file_contents($url) {
 
-		$headers = [
-			'Authorization: Bearer ' . get_option('wc_settings_woocommercenfe_bearer_access_token'),
-			'X-Access-Token: ' . get_option('wc_settings_woocommercenfe_access_token'),
-			'X-Access-Token-Secret: ' . get_option('wc_settings_woocommercenfe_access_token_secret'),
-			'X-Consumer-Key: ' . get_option('wc_settings_woocommercenfe_consumer_key'),
-			'X-Consumer-Secret: ' . get_option('wc_settings_woocommercenfe_consumer_secret')
-		];
+		// Security: Build headers securely
+		$headers = [];
+		$bearer_token = get_option('wc_settings_woocommercenfe_bearer_access_token');
+		$access_token = get_option('wc_settings_woocommercenfe_access_token');
+		$access_token_secret = get_option('wc_settings_woocommercenfe_access_token_secret');
+		$consumer_key = get_option('wc_settings_woocommercenfe_consumer_key');
+		$consumer_secret = get_option('wc_settings_woocommercenfe_consumer_secret');
+
+		if ($bearer_token) {
+			$headers[] = 'Authorization: Bearer ' . $bearer_token;
+		}
+		if ($access_token) {
+			$headers[] = 'X-Access-Token: ' . $access_token;
+		}
+		if ($access_token_secret) {
+			$headers[] = 'X-Access-Token-Secret: ' . $access_token_secret;
+		}
+		if ($consumer_key) {
+			$headers[] = 'X-Consumer-Key: ' . $consumer_key;
+		}
+		if ($consumer_secret) {
+			$headers[] = 'X-Consumer-Secret: ' . $consumer_secret;
+		}
 
 		$c = curl_init();
 
+		// Security: Secure cURL options
 		curl_setopt($c, CURLOPT_URL, $url);
 		curl_setopt($c, CURLOPT_HTTPGET, true);
 		curl_setopt($c, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($c, CURLOPT_HTTPHEADER, $headers);
+		curl_setopt($c, CURLOPT_TIMEOUT, 30); // Prevent hanging
+		curl_setopt($c, CURLOPT_CONNECTTIMEOUT, 10);
+		curl_setopt($c, CURLOPT_MAXREDIRS, 3); // Limit redirects
+		curl_setopt($c, CURLOPT_FOLLOWLOCATION, true);
+		curl_setopt($c, CURLOPT_PROTOCOLS, CURLPROTO_HTTPS); // Only HTTPS
+		curl_setopt($c, CURLOPT_SSL_VERIFYPEER, true); // Verify SSL
+		curl_setopt($c, CURLOPT_SSL_VERIFYHOST, 2);
+		curl_setopt($c, CURLOPT_USERAGENT, 'WooCommerce-NFe-Plugin/' . WC_NFe()->version);
 
 		$contents = curl_exec($c);
+		$http_code = curl_getinfo($c, CURLINFO_HTTP_CODE);
+		$curl_error = curl_error($c);
 		
 		curl_close($c);
 
-		if(strpos($contents, 'error') !== false) return false;
+		// Security: Validate response
+		if ($curl_error || $http_code !== 200) {
+			error_log('WooCommerceNFe: cURL error - ' . $curl_error . ' HTTP: ' . $http_code);
+			return false;
+		}
 
-		return $contents ?? false;
+		if (!$contents || strpos($contents, 'error') !== false) {
+			return false;
+		}
+
+		// Security: Limit file size to prevent memory exhaustion
+		if (strlen($contents) > 10 * 1024 * 1024) { // 10MB limit
+			error_log('WooCommerceNFe: File too large');
+			return false;
+		}
+
+		return $contents;
 	}
 }

--- a/inc/class-security.php
+++ b/inc/class-security.php
@@ -1,0 +1,396 @@
+<?php
+/**
+ * Security Helper Class for WooCommerce NFe
+ * 
+ * @package WooCommerceNFe
+ * @since 3.4.0.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+class WooCommerceNFe_Security {
+
+	/**
+	 * Sanitize and validate order ID
+	 * 
+	 * @param mixed $order_id
+	 * @return int|false
+	 */
+	public static function validate_order_id( $order_id ) {
+		$order_id = absint( $order_id );
+		
+		if ( $order_id <= 0 ) {
+			return false;
+		}
+		
+		$order = wc_get_order( $order_id );
+		if ( ! $order ) {
+			return false;
+		}
+		
+		return $order_id;
+	}
+
+	/**
+	 * Validate and sanitize CPF
+	 * 
+	 * @param string $cpf
+	 * @return string|false
+	 */
+	public static function sanitize_cpf( $cpf ) {
+		$cpf = preg_replace( '/[^0-9]/', '', $cpf );
+		
+		if ( strlen( $cpf ) !== 11 ) {
+			return false;
+		}
+		
+		if ( ! WooCommerceNFeFormat::is_cpf( $cpf ) ) {
+			return false;
+		}
+		
+		return $cpf;
+	}
+
+	/**
+	 * Validate and sanitize CNPJ
+	 * 
+	 * @param string $cnpj
+	 * @return string|false
+	 */
+	public static function sanitize_cnpj( $cnpj ) {
+		$cnpj = preg_replace( '/[^0-9]/', '', $cnpj );
+		
+		if ( strlen( $cnpj ) !== 14 ) {
+			return false;
+		}
+		
+		if ( ! WooCommerceNFeFormat::is_cnpj( $cnpj ) ) {
+			return false;
+		}
+		
+		return $cnpj;
+	}
+
+	/**
+	 * Sanitize monetary value
+	 * 
+	 * @param mixed $value
+	 * @return float
+	 */
+	public static function sanitize_money( $value ) {
+		$value = str_replace( array( 'R$', '€', '$', ' ' ), '', $value );
+		$value = str_replace( ',', '.', $value );
+		return floatval( $value );
+	}
+
+	/**
+	 * Validate URL
+	 * 
+	 * @param string $url
+	 * @return string|false
+	 */
+	public static function validate_url( $url ) {
+		$url = esc_url_raw( $url );
+		
+		if ( ! filter_var( $url, FILTER_VALIDATE_URL ) ) {
+			return false;
+		}
+		
+		// Only allow http and https protocols
+		$parsed = parse_url( $url );
+		if ( ! in_array( $parsed['scheme'], array( 'http', 'https' ), true ) ) {
+			return false;
+		}
+		
+		return $url;
+	}
+
+	/**
+	 * Create secure nonce for AJAX requests
+	 * 
+	 * @param string $action
+	 * @return string
+	 */
+	public static function create_ajax_nonce( $action ) {
+		return wp_create_nonce( 'woocommerce_nfe_' . $action . '_' . get_current_user_id() );
+	}
+
+	/**
+	 * Verify AJAX nonce
+	 * 
+	 * @param string $action
+	 * @param string $nonce_field
+	 * @return bool
+	 */
+	public static function verify_ajax_nonce( $action, $nonce_field = 'security' ) {
+		return check_ajax_referer( 'woocommerce_nfe_' . $action . '_' . get_current_user_id(), $nonce_field, false );
+	}
+
+	/**
+	 * Sanitize array recursively
+	 * 
+	 * @param array $array
+	 * @return array
+	 */
+	public static function sanitize_array( $array ) {
+		if ( ! is_array( $array ) ) {
+			return sanitize_text_field( $array );
+		}
+		
+		foreach ( $array as $key => $value ) {
+			if ( is_array( $value ) ) {
+				$array[ $key ] = self::sanitize_array( $value );
+			} else {
+				$array[ $key ] = sanitize_text_field( $value );
+			}
+		}
+		
+		return $array;
+	}
+
+	/**
+	 * Validate date format
+	 * 
+	 * @param string $date
+	 * @param string $format
+	 * @return bool
+	 */
+	public static function validate_date( $date, $format = 'd/m/Y' ) {
+		$d = DateTime::createFromFormat( $format, $date );
+		return $d && $d->format( $format ) === $date;
+	}
+
+	/**
+	 * Get safe user IP address
+	 * 
+	 * @return string
+	 */
+	public static function get_user_ip() {
+		// Check for CloudFlare IP
+		if ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+			$ip = $_SERVER['HTTP_CF_CONNECTING_IP'];
+		}
+		// Check for proxy
+		elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+			$ips = explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] );
+			$ip = trim( $ips[0] );
+		}
+		// Standard IP
+		elseif ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+			$ip = $_SERVER['REMOTE_ADDR'];
+		}
+		else {
+			$ip = 'unknown';
+		}
+		
+		// Validate IP address
+		if ( ! filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+			return 'invalid';
+		}
+		
+		return $ip;
+	}
+
+	/**
+	 * Rate limiting for API calls
+	 * 
+	 * @param string $action
+	 * @param int $limit
+	 * @param int $window (in seconds)
+	 * @return bool
+	 */
+	public static function check_rate_limit( $action, $limit = 10, $window = 60 ) {
+		$user_id = get_current_user_id();
+		$ip = self::get_user_ip();
+		$key = 'nfe_rate_limit_' . $action . '_' . $user_id . '_' . $ip;
+		
+		$attempts = get_transient( $key );
+		
+		if ( $attempts === false ) {
+			set_transient( $key, 1, $window );
+			return true;
+		}
+		
+		if ( $attempts >= $limit ) {
+			return false;
+		}
+		
+		set_transient( $key, $attempts + 1, $window );
+		return true;
+	}
+
+	/**
+	 * Sanitize file name
+	 * 
+	 * @param string $filename
+	 * @return string
+	 */
+	public static function sanitize_filename( $filename ) {
+		$filename = sanitize_file_name( $filename );
+		
+		// Remove any remaining special characters
+		$filename = preg_replace( '/[^a-zA-Z0-9._-]/', '', $filename );
+		
+		// Ensure it has a safe extension
+		$allowed_extensions = array( 'pdf', 'xml', 'txt', 'csv' );
+		$extension = pathinfo( $filename, PATHINFO_EXTENSION );
+		
+		if ( ! in_array( strtolower( $extension ), $allowed_extensions, true ) ) {
+			return false;
+		}
+		
+		return $filename;
+	}
+
+	/**
+	 * Generate secure random token
+	 * 
+	 * @param int $length
+	 * @return string
+	 */
+	public static function generate_token( $length = 32 ) {
+		if ( function_exists( 'wp_generate_password' ) ) {
+			return wp_generate_password( $length, false );
+		}
+		
+		return bin2hex( random_bytes( $length / 2 ) );
+	}
+
+	/**
+	 * Escape output for JavaScript
+	 * 
+	 * @param mixed $data
+	 * @return string
+	 */
+	public static function escape_js( $data ) {
+		if ( is_array( $data ) || is_object( $data ) ) {
+			return wp_json_encode( $data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP );
+		}
+		
+		return esc_js( $data );
+	}
+
+	/**
+	 * Validate webhook signature
+	 * 
+	 * @param string $payload
+	 * @param string $signature
+	 * @param string $secret
+	 * @return bool
+	 */
+	public static function validate_webhook_signature( $payload, $signature, $secret ) {
+		$calculated_signature = hash_hmac( 'sha256', $payload, $secret );
+		return hash_equals( $calculated_signature, $signature );
+	}
+
+	/**
+	 * Log security events
+	 * 
+	 * @param string $event_type
+	 * @param array $data
+	 * @return void
+	 */
+	public static function log_security_event( $event_type, $data = array() ) {
+		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {
+			return;
+		}
+		
+		$log_entry = array(
+			'timestamp' => current_time( 'mysql' ),
+			'event' => sanitize_text_field( $event_type ),
+			'user_id' => get_current_user_id(),
+			'ip' => self::get_user_ip(),
+			'data' => self::sanitize_array( $data )
+		);
+		
+		// Log to WordPress debug log
+		error_log( 'NFe Security Event: ' . wp_json_encode( $log_entry ) );
+		
+		// Optionally store in database for audit trail
+		if ( apply_filters( 'woocommerce_nfe_enable_security_audit', false ) ) {
+			add_option( 'nfe_security_log_' . time() . '_' . wp_rand(), $log_entry, '', 'no' );
+		}
+	}
+
+	/**
+	 * Validate API credentials
+	 * 
+	 * @param array $credentials
+	 * @return bool
+	 */
+	public static function validate_api_credentials( $credentials ) {
+		$required_fields = array(
+			'consumer_key',
+			'consumer_secret',
+			'oauth_access_token',
+			'oauth_access_token_secret'
+		);
+		
+		foreach ( $required_fields as $field ) {
+			if ( empty( $credentials[ $field ] ) ) {
+				return false;
+			}
+			
+			// Basic length validation
+			if ( strlen( $credentials[ $field ] ) < 10 ) {
+				return false;
+			}
+		}
+		
+		return true;
+	}
+
+	/**
+	 * Add security headers
+	 * 
+	 * @return void
+	 */
+	public static function add_security_headers() {
+		if ( ! headers_sent() ) {
+			header( 'X-Content-Type-Options: nosniff' );
+			header( 'X-Frame-Options: SAMEORIGIN' );
+			header( 'X-XSS-Protection: 1; mode=block' );
+			header( 'Referrer-Policy: strict-origin-when-cross-origin' );
+			
+			if ( is_ssl() ) {
+				header( 'Strict-Transport-Security: max-age=31536000; includeSubDomains' );
+			}
+		}
+	}
+
+	/**
+	 * Validate AJAX request
+	 * 
+	 * @param string $action
+	 * @param string $capability
+	 * @return bool
+	 */
+	public static function validate_ajax_request( $action, $capability = 'manage_woocommerce' ) {
+		// Check if it's an AJAX request
+		if ( ! wp_doing_ajax() ) {
+			return false;
+		}
+		
+		// Verify nonce
+		if ( ! self::verify_ajax_nonce( $action ) ) {
+			wp_send_json_error( array( 'message' => __( 'Security check failed', 'woocommerce' ) ), 403 );
+			return false;
+		}
+		
+		// Check user capability
+		if ( ! current_user_can( $capability ) ) {
+			wp_send_json_error( array( 'message' => __( 'Insufficient permissions', 'woocommerce' ) ), 403 );
+			return false;
+		}
+		
+		// Rate limiting
+		if ( ! self::check_rate_limit( 'ajax_' . $action, 30, 60 ) ) {
+			wp_send_json_error( array( 'message' => __( 'Too many requests. Please try again later.', 'woocommerce' ) ), 429 );
+			return false;
+		}
+		
+		return true;
+	}
+}

--- a/inc/sdk/NFSe.php
+++ b/inc/sdk/NFSe.php
@@ -6,7 +6,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class NFSe {
 
-	function __construct( string $token ){
+	public string $token = '';
+
+	public function __construct( string $token ) {
 
 		$this->token = $token;
 
@@ -21,6 +23,7 @@ class NFSe {
 
 	function consultaNotaFiscal( $uuid ){
 
+			$data = array();
 			$response = self::connectWebmaniaBR( 'GET', 'https://api.webmaniabr.com/2/nfse/consulta/'.$uuid, $data );
 			return $response;
 
@@ -76,8 +79,8 @@ class NFSe {
 			curl_setopt($rest, CURLOPT_TIMEOUT, $timeout);
 			curl_setopt($rest, CURLOPT_URL, $endpoint);
 			curl_setopt($rest, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($rest, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($rest, CURLOPT_SSL_VERIFYHOST, false);
+			curl_setopt($rest, CURLOPT_SSL_VERIFYPEER, true);
+			curl_setopt($rest, CURLOPT_SSL_VERIFYHOST, 2);
 			curl_setopt($rest, CURLOPT_CUSTOMREQUEST, $request);
 			curl_setopt($rest, CURLOPT_POSTFIELDS, json_encode( $data ));
 			curl_setopt($rest, CURLOPT_HTTPHEADER, $headers);
@@ -99,14 +102,8 @@ class NFSe {
 
 			// Get cURL errors
 			$curl_error = new StdClass;
-			// Get User IP
-			$ip = $_SERVER['CF-Connecting-IP']; // CloudFlare
-			if (!$ip){
-				$ip = $_SERVER['REMOTE_ADDR']; // Standard
-			}
-			if (is_array($ip)){
-				$ip = $ip[0];
-			}
+			// Security: Get User IP safely 
+			$ip = $this->get_user_ip();
 			// cURL errors
 			if (!$http_status){
 				$curl_error->error = 'Não foi possível obter conexão na API da WebmaniaBR®, possível relação com bloqueio no Firewall ou versão antiga do PHP. Verifique junto ao programador e a sua hospedagem a comunicação na URL: '.$endpoint.'. (cURL: '.$curl_strerror.' | PHP: '.phpversion().' | cURL: '.curl_version()['version'].')';
@@ -143,6 +140,48 @@ class NFSe {
 			$unit = strtolower(substr(trim($value), -1));
 			return $multipliers[$unit] ?? 1 * (int)$value;
 
+	}
+
+	/**
+	 * Security: Get real user IP address safely
+	 * 
+	 * @return string
+	 */
+	private function get_user_ip() {
+		
+		// List of possible IP headers in order of preference
+		$ip_headers = [
+			'HTTP_CF_CONNECTING_IP',     // CloudFlare
+			'HTTP_CLIENT_IP',            // Proxy
+			'HTTP_X_FORWARDED_FOR',      // Load Balancer/Proxy
+			'HTTP_X_FORWARDED',          // Proxy
+			'HTTP_X_CLUSTER_CLIENT_IP',  // Cluster
+			'HTTP_FORWARDED_FOR',        // Proxy
+			'HTTP_FORWARDED',            // Proxy
+			'REMOTE_ADDR'                // Standard
+		];
+		
+		foreach ($ip_headers as $header) {
+			if (!empty($_SERVER[$header])) {
+				$ip_list = $_SERVER[$header];
+				
+				// Handle comma-separated IPs
+				if (strpos($ip_list, ',') !== false) {
+					$ip_list = explode(',', $ip_list);
+					$ip = trim($ip_list[0]);
+				} else {
+					$ip = trim($ip_list);
+				}
+				
+				// Validate IP address
+				if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+					return $ip;
+				}
+			}
+		}
+		
+		// Fallback to REMOTE_ADDR even if private/reserved
+		return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown';
 	}
 
 }

--- a/inc/sdk/NFe.php
+++ b/inc/sdk/NFe.php
@@ -6,7 +6,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class NFe {
 
-	function __construct( array $vars ){
+	public string $consumerKey = '';
+	public string $consumerSecret = '';
+	public string $accessToken = '';
+	public string $accessTokenSecret = '';
+
+	public function __construct( array $vars ) {
 
 			$this->consumerKey = $vars['consumer_key'];
 			$this->consumerSecret = $vars['consumer_secret'];
@@ -150,8 +155,8 @@ class NFe {
 			curl_setopt($rest, CURLOPT_TIMEOUT, $timeout);
 			curl_setopt($rest, CURLOPT_URL, $endpoint);
 			curl_setopt($rest, CURLOPT_RETURNTRANSFER, true);
-			curl_setopt($rest, CURLOPT_SSL_VERIFYPEER, false);
-			curl_setopt($rest, CURLOPT_SSL_VERIFYHOST, false);
+			curl_setopt($rest, CURLOPT_SSL_VERIFYPEER, true);
+			curl_setopt($rest, CURLOPT_SSL_VERIFYHOST, 2);
 			curl_setopt($rest, CURLOPT_CUSTOMREQUEST, $request);
 			curl_setopt($rest, CURLOPT_POSTFIELDS, json_encode( $data ));
 			curl_setopt($rest, CURLOPT_HTTPHEADER, $headers);
@@ -174,14 +179,8 @@ class NFe {
 			// Get cURL errors
 			$curl_error = new StdClass;
 			if ($curl_errno){
-				// Get User IP
-				$ip = $_SERVER['CF-Connecting-IP']; // CloudFlare
-				if (!$ip){
-					$ip = $_SERVER['REMOTE_ADDR']; // Standard
-				}
-				if (is_array($ip)){
-					$ip = $ip[0];
-				}
+				// Security: Get User IP safely
+				$ip = $this->get_user_ip();
 
 				// cURL errors
 				if (!$http_status){
@@ -220,6 +219,48 @@ class NFe {
 			$unit = strtolower(substr(trim($value), -1));
 			return $multipliers[$unit] ?? 1 * (int)$value;
 
+	}
+
+	/**
+	 * Security: Get real user IP address safely
+	 * 
+	 * @return string
+	 */
+	private function get_user_ip() {
+		
+		// List of possible IP headers in order of preference
+		$ip_headers = [
+			'HTTP_CF_CONNECTING_IP',     // CloudFlare
+			'HTTP_CLIENT_IP',            // Proxy
+			'HTTP_X_FORWARDED_FOR',      // Load Balancer/Proxy
+			'HTTP_X_FORWARDED',          // Proxy
+			'HTTP_X_CLUSTER_CLIENT_IP',  // Cluster
+			'HTTP_FORWARDED_FOR',        // Proxy
+			'HTTP_FORWARDED',            // Proxy
+			'REMOTE_ADDR'                // Standard
+		];
+		
+		foreach ($ip_headers as $header) {
+			if (!empty($_SERVER[$header])) {
+				$ip_list = $_SERVER[$header];
+				
+				// Handle comma-separated IPs
+				if (strpos($ip_list, ',') !== false) {
+					$ip_list = explode(',', $ip_list);
+					$ip = trim($ip_list[0]);
+				} else {
+					$ip = trim($ip_list);
+				}
+				
+				// Validate IP address
+				if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)) {
+					return $ip;
+				}
+			}
+		}
+		
+		// Fallback to REMOTE_ADDR even if private/reserved
+		return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'unknown';
 	}
 
 }

--- a/inc/utils.php
+++ b/inc/utils.php
@@ -14,17 +14,19 @@ class NFeUtils {
     // Vars
     $order = wc_get_order( $post_id );
     $data['parcelas'] = array();
-    $nfe_installments_n = ($_POST['nfe_installments_n']) ? $_POST['nfe_installments_n'] : $order->get_meta( '_nfe_installments_n' );
+    $nfe_installments_n = (isset($_POST['nfe_installments_n'])) ? (int) $_POST['nfe_installments_n'] : (int) $order->get_meta( '_nfe_installments_n' );
     $nfe_installments_n = ($nfe_installments_n) ? $nfe_installments_n : 0;
-    $nfe_installments_due_date = ($_POST['nfe_installments_due_date']) ? $_POST['nfe_installments_due_date'] : $order->get_meta( '_nfe_installments_due_date' );
-    $nfe_installments_value = ($_POST['nfe_installments_value']) ? $_POST['nfe_installments_value'] : $order->get_meta( '_nfe_installments_value' );
+    $nfe_installments_due_date = (isset($_POST['nfe_installments_due_date']) && is_array($_POST['nfe_installments_due_date'])) ? array_map('sanitize_text_field', $_POST['nfe_installments_due_date']) : (array) $order->get_meta( '_nfe_installments_due_date' );
+    $nfe_installments_value = (isset($_POST['nfe_installments_value']) && is_array($_POST['nfe_installments_value'])) ? array_map('sanitize_text_field', $_POST['nfe_installments_value']) : (array) $order->get_meta( '_nfe_installments_value' );
     $order_total = 0;
 
     // Installments
     for ($i = 0; $i < $nfe_installments_n; $i++){
 
-      $invoice_date = date('Y-m-d', strtotime(str_replace("/", "-", $nfe_installments_due_date[$i])));
-      $value = number_format(str_replace(',', '.', str_replace('R$', '', $nfe_installments_value[$i])), 2, '.', '');
+      $date_src = isset($nfe_installments_due_date[$i]) ? $nfe_installments_due_date[$i] : '';
+      $value_src = isset($nfe_installments_value[$i]) ? $nfe_installments_value[$i] : '0';
+      $invoice_date = date('Y-m-d', strtotime(str_replace("/", "-", sanitize_text_field($date_src) )));
+      $value = number_format((float) str_replace(',', '.', str_replace('R$', '', $value_src)), 2, '.', '');
       $order_total += $value;
 
       $data['parcelas'][] = array(

--- a/init-class.php
+++ b/init-class.php
@@ -6,24 +6,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WooCommerceNFe {
 
-	public $domain = 'WooCommerceNFe';
-	public $version = '3.4.0.3';
-	protected static $_instance = NULL;
+	public string $domain = 'WooCommerceNFe';
+	public string $version = '3.4.4';
+	public array $settings = [];
+	protected static ?WooCommerceNFe $_instance = null;
 
 	public static function instance() {
     if ( is_null( self::$_instance ) ) {
-      self::$_instance = new self();
-    }
-    return self::$_instance;
-  }
+			self::$_instance = new self();
+		}
+		return self::$_instance;
+	}
 
-  public function __get( $key ) {
-    return $this->$key();
+  	public function __get( $key ) {
+		// Security: Restrict access to safe properties only
+		$allowed_properties = array(
+			'domain',
+			'version',
+			'settings'
+		);
+		
+		if ( in_array( $key, $allowed_properties, true ) ) {
+			return $this->$key;
+		}
+		
+		// Security: Log potential security attempt without exposing user input
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( 'WooCommerceNFe: Attempted access to restricted property' );
+		}
+		return null;
 	}
 
 	function __construct(){
 
 		global $domain, $woocommerce;
+
+		// Load hook message
+		add_action( 'admin_notices', [ $this, 'display_messages' ] );
 
 		// Validate plugin before Load
 		if (!$this->validate_plugin()){
@@ -71,9 +90,11 @@ class WooCommerceNFe {
 		}
 
 		// WooCommerce Version
-		$vars = get_object_vars($woocommerce);
+		$wc_version = defined('WC_VERSION')
+			? constant('WC_VERSION')
+			: (function_exists('WC') ? WC()->version : '0.0.0');
 
-		if ($vars['version'] < '3.0.0'){
+		if (version_compare($wc_version, '3.0.0', '<')){
 			$this->add_error( __('<strong>Nota Fiscal WebmaniaBR®:</strong> Atualize o WooCommerce para a versão 3.0.0 ou superior.', $this->domain) );
 			return false;
 		}
@@ -161,6 +182,7 @@ class WooCommerceNFe {
 	 */
 	function includes(){
 
+		include_once( 'inc/class-security.php' ); // Security helper class
 		include_once( 'inc/sdk/NFe.php' );
 		include_once( 'inc/sdk/NFSe.php' );
 		include_once( 'inc/utils.php' );
@@ -279,7 +301,7 @@ class WooCommerceNFe {
 			$to == 'wc-completed' && $option == 2
 		){
 			
-			$nfes = get_post_meta( $order->id,  'nfe', true );
+			$nfes = $order->get_meta('nfe');
 
 			if ( !empty($nfes) && is_array($nfes) ) {
 				foreach ( $nfes as $nfe ) {
@@ -315,14 +337,35 @@ class WooCommerceNFe {
 			return;
 		}
 
-		$subject = 'Erro ao emitir NF-e - Pedido #'.$order_id;
-		$message = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+		// Security: Validate email address
+		if (!is_email($email)) {
+			if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+				error_log('WooCommerceNFe: Invalid email address for notifications');
+			}
+			return;
+		}
+
+		// Security: Sanitize inputs to prevent header injection
+		$order_id = intval($order_id);
+		$safe_message = wp_kses($message, array(
+			'p' => array(),
+			'br' => array(),
+			'strong' => array(),
+			'ul' => array(),
+			'li' => array()
+		));
+
+		// Security: Properly escape subject and URL
+		$subject = esc_html( sprintf('Erro ao emitir NF-e - Pedido #%d', $order_id) );
+		$admin_url = esc_url( admin_url( 'post.php?post=' . $order_id . '&action=edit' ) );
+		
+		$html_message = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 		  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 		  <html xmlns="http://www.w3.org/1999/xhtml">
 		  <head><meta charset="UTF-8"></head>
 		  	<body>
-		  		<p>Houve um erro de emissão automatica no Pedido #'.$order_id.': <a target="_blank" href="'.get_admin_url().'/post.php?post='.$order_id.'&action=edit">Acesse o pedido</a></p>
-		  		'.$message.'
+		  		<p>Houve um erro de emissão automática no Pedido #' . esc_html($order_id) . ': <a target="_blank" href="' . $admin_url . '">Acesse o pedido</a></p>
+		  		' . $safe_message . '
 			</body>
 		</html>';
 
@@ -330,8 +373,10 @@ class WooCommerceNFe {
 		  	'Content-Type: text/html; charset=UTF-8'
 		);
 
-		$emails = array($email);
-		$enviar_email = wp_mail($emails, $subject, $message, $headers);
+		// Security: Use single email address, validate before sending
+		if ( is_email( $email ) ) {
+			$enviar_email = wp_mail( sanitize_email( $email ), $subject, $html_message, $headers );
+		}
 
 	}
 
@@ -353,9 +398,11 @@ class WooCommerceNFe {
 	**/
 	public static function plugin_add_settings_link( $links ) {
 
+	    // Security: Escape URL and add nonce
+	    $settings_url = esc_url( admin_url( 'admin.php?page=wc-settings&tab=woocommercenfe_tab' ) );
 	    $action_links = array(
-	      'settings' => '<a href="' . admin_url( 'admin.php?page=wc-settings&tab=woocommercenfe_tab' ) . '" aria-label="Visualizar Configurações">Configurações</a>',
-			);
+	      'settings' => '<a href="' . $settings_url . '" aria-label="' . esc_attr__( 'Visualizar Configurações', 'woocommerce' ) . '">' . esc_html__( 'Configurações', 'woocommerce' ) . '</a>',
+		);
 
 	    return array_merge( $action_links, $links );
 	}
@@ -412,6 +459,53 @@ class WooCommerceNFe {
 		}
 
 		return true;
+
+	}
+
+	/**
+	 * Display Messages
+	 *
+	 * @return void
+	 */
+	public function display_messages(): void {
+
+		$error_messages = get_option('woocommercenfe_error_messages');
+		if ( $error_messages && is_array( $error_messages ) ) {
+			?>
+			<div class="notice notice-error is-dismissible">
+				<?php 
+				foreach ( $error_messages as $message ) { 
+					// Security: Allow specific HTML tags in admin notices
+					echo '<p>' . wp_kses( $message, array(
+						'strong' => array(),
+						'a' => array( 'href' => array(), 'target' => array() ),
+						'ul' => array(),
+						'li' => array()
+					) ) . '</p>'; 
+				} 
+				?>
+			</div>
+			<?php
+			delete_option('woocommercenfe_error_messages');
+		}
+
+		$success_messages = get_option('woocommercenfe_success_messages');
+		if ( $success_messages && is_array( $success_messages ) ) {
+			?>
+			<div class="notice notice-success is-dismissible">
+				<?php 
+				foreach ( $success_messages as $message ) { 
+					// Security: Allow specific HTML tags in admin notices
+					echo '<p>' . wp_kses( $message, array(
+						'strong' => array(),
+						'a' => array( 'href' => array(), 'target' => array(), 'rel' => array() )
+					) ) . '</p>'; 
+				} 
+				?>
+			</div>
+			<?php
+			delete_option('woocommercenfe_success_messages');
+		}
 
 	}
 

--- a/security-config.php
+++ b/security-config.php
@@ -1,0 +1,316 @@
+<?php
+/**
+ * Security Configuration for WooCommerce NFe
+ * 
+ * This file contains security settings and constants for the plugin
+ * 
+ * @package WooCommerceNFe
+ * @since 3.4.0.7
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+// Security Constants
+define( 'WOOCOMMERCE_NFE_SECURITY_VERSION', '1.0.0' );
+
+// Rate Limiting Settings
+define( 'WOOCOMMERCE_NFE_RATE_LIMIT_ENABLED', true );
+define( 'WOOCOMMERCE_NFE_RATE_LIMIT_REQUESTS', 30 ); // Maximum requests
+define( 'WOOCOMMERCE_NFE_RATE_LIMIT_WINDOW', 60 ); // Time window in seconds
+
+// Session Security
+define( 'WOOCOMMERCE_NFE_SESSION_TIMEOUT', 3600 ); // 1 hour
+define( 'WOOCOMMERCE_NFE_SESSION_REGENERATE', 1800 ); // Regenerate session ID every 30 minutes
+
+// File Upload Security
+define( 'WOOCOMMERCE_NFE_MAX_FILE_SIZE', 104857600 ); // 100MB in bytes
+define( 'WOOCOMMERCE_NFE_ALLOWED_FILE_TYPES', array( 'pdf', 'xml', 'txt', 'csv' ) );
+
+// API Security
+define( 'WOOCOMMERCE_NFE_API_TIMEOUT', 30 ); // API timeout in seconds
+define( 'WOOCOMMERCE_NFE_API_MAX_RETRIES', 3 ); // Maximum API retry attempts
+
+// Logging Security
+define( 'WOOCOMMERCE_NFE_LOG_SENSITIVE_DATA', false ); // Don't log sensitive data
+define( 'WOOCOMMERCE_NFE_LOG_IP_ADDRESSES', false ); // Don't log IP addresses
+define( 'WOOCOMMERCE_NFE_LOG_RETENTION_DAYS', 30 ); // Delete logs after 30 days
+
+// CSRF Protection
+define( 'WOOCOMMERCE_NFE_CSRF_TOKEN_LIFETIME', 7200 ); // 2 hours
+
+// Password Requirements (for any future password fields)
+define( 'WOOCOMMERCE_NFE_MIN_PASSWORD_LENGTH', 12 );
+define( 'WOOCOMMERCE_NFE_REQUIRE_SPECIAL_CHARS', true );
+define( 'WOOCOMMERCE_NFE_REQUIRE_NUMBERS', true );
+define( 'WOOCOMMERCE_NFE_REQUIRE_UPPERCASE', true );
+
+// Security Headers (if not set by server)
+if ( ! headers_sent() ) {
+	// Prevent MIME sniffing
+	header( 'X-Content-Type-Options: nosniff' );
+	
+	// Prevent clickjacking
+	header( 'X-Frame-Options: SAMEORIGIN' );
+	
+	// Enable XSS protection
+	header( 'X-XSS-Protection: 1; mode=block' );
+	
+	// Referrer Policy
+	header( 'Referrer-Policy: strict-origin-when-cross-origin' );
+	
+	// Remove PHP version
+	header_remove( 'X-Powered-By' );
+	
+	// HSTS (only on HTTPS)
+	if ( is_ssl() ) {
+		header( 'Strict-Transport-Security: max-age=31536000; includeSubDomains' );
+	}
+}
+
+/**
+ * Security functions
+ */
+
+/**
+ * Check if security features are enabled
+ * 
+ * @return bool
+ */
+function woocommerce_nfe_is_security_enabled() {
+	return apply_filters( 'woocommerce_nfe_security_enabled', true );
+}
+
+/**
+ * Get security configuration
+ * 
+ * @param string $key Configuration key
+ * @param mixed $default Default value
+ * @return mixed
+ */
+function woocommerce_nfe_get_security_config( $key, $default = null ) {
+	$config = array(
+		'rate_limiting' => WOOCOMMERCE_NFE_RATE_LIMIT_ENABLED,
+		'rate_limit_requests' => WOOCOMMERCE_NFE_RATE_LIMIT_REQUESTS,
+		'rate_limit_window' => WOOCOMMERCE_NFE_RATE_LIMIT_WINDOW,
+		'session_timeout' => WOOCOMMERCE_NFE_SESSION_TIMEOUT,
+		'max_file_size' => WOOCOMMERCE_NFE_MAX_FILE_SIZE,
+		'allowed_file_types' => WOOCOMMERCE_NFE_ALLOWED_FILE_TYPES,
+		'api_timeout' => WOOCOMMERCE_NFE_API_TIMEOUT,
+		'csrf_token_lifetime' => WOOCOMMERCE_NFE_CSRF_TOKEN_LIFETIME,
+	);
+	
+	return isset( $config[ $key ] ) ? $config[ $key ] : $default;
+}
+
+/**
+ * Validate request origin
+ * 
+ * @return bool
+ */
+function woocommerce_nfe_validate_request_origin() {
+	// Check if request is from same origin
+	if ( isset( $_SERVER['HTTP_REFERER'] ) ) {
+		$referer = parse_url( $_SERVER['HTTP_REFERER'] );
+		$site_url = parse_url( site_url() );
+		
+		if ( $referer['host'] !== $site_url['host'] ) {
+			return false;
+		}
+	}
+	
+	return true;
+}
+
+/**
+ * Clean old log files
+ * 
+ * @return void
+ */
+function woocommerce_nfe_clean_old_logs() {
+	if ( ! WOOCOMMERCE_NFE_LOG_RETENTION_DAYS ) {
+		return;
+	}
+	
+	$upload_dir = wp_upload_dir();
+	$log_dir = $upload_dir['basedir'] . '/woocommerce-nfe-logs/';
+	
+	if ( ! is_dir( $log_dir ) ) {
+		return;
+	}
+	
+	$files = glob( $log_dir . '*.log' );
+	$now = time();
+	$retention_seconds = WOOCOMMERCE_NFE_LOG_RETENTION_DAYS * 86400;
+	
+	foreach ( $files as $file ) {
+		if ( is_file( $file ) ) {
+			if ( $now - filemtime( $file ) >= $retention_seconds ) {
+				@unlink( $file );
+			}
+		}
+	}
+}
+
+// Schedule log cleanup
+if ( ! wp_next_scheduled( 'woocommerce_nfe_clean_logs' ) ) {
+	wp_schedule_event( time(), 'daily', 'woocommerce_nfe_clean_logs' );
+}
+add_action( 'woocommerce_nfe_clean_logs', 'woocommerce_nfe_clean_old_logs' );
+
+/**
+ * Validate input length
+ * 
+ * @param string $input
+ * @param int $max_length
+ * @return bool
+ */
+function woocommerce_nfe_validate_input_length( $input, $max_length = 1000 ) {
+	return strlen( $input ) <= $max_length;
+}
+
+/**
+ * Sanitize file path
+ * 
+ * @param string $path
+ * @return string|false
+ */
+function woocommerce_nfe_sanitize_file_path( $path ) {
+	// Remove any directory traversal attempts
+	$path = str_replace( array( '../', '..\\' ), '', $path );
+	
+	// Remove null bytes
+	$path = str_replace( chr(0), '', $path );
+	
+	// Normalize slashes
+	$path = str_replace( '\\', '/', $path );
+	
+	// Remove multiple slashes
+	$path = preg_replace( '#/+#', '/', $path );
+	
+	// Check if path is within allowed directories
+	$upload_dir = wp_upload_dir();
+	$allowed_dirs = array(
+		ABSPATH,
+		WP_CONTENT_DIR,
+		$upload_dir['basedir']
+	);
+	
+	$is_allowed = false;
+	foreach ( $allowed_dirs as $dir ) {
+		if ( strpos( $path, $dir ) === 0 ) {
+			$is_allowed = true;
+			break;
+		}
+	}
+	
+	if ( ! $is_allowed ) {
+		return false;
+	}
+	
+	return $path;
+}
+
+/**
+ * Create secure hash
+ * 
+ * @param string $data
+ * @param string $key Optional key for HMAC
+ * @return string
+ */
+function woocommerce_nfe_create_hash( $data, $key = '' ) {
+	if ( empty( $key ) ) {
+		$key = wp_salt( 'auth' );
+	}
+	
+	return hash_hmac( 'sha256', $data, $key );
+}
+
+/**
+ * Verify secure hash
+ * 
+ * @param string $data
+ * @param string $hash
+ * @param string $key Optional key for HMAC
+ * @return bool
+ */
+function woocommerce_nfe_verify_hash( $data, $hash, $key = '' ) {
+	$expected = woocommerce_nfe_create_hash( $data, $key );
+	return hash_equals( $expected, $hash );
+}
+
+/**
+ * Get client IP address safely
+ * 
+ * @return string
+ */
+function woocommerce_nfe_get_client_ip() {
+	// Don't log IPs if disabled
+	if ( ! WOOCOMMERCE_NFE_LOG_IP_ADDRESSES ) {
+		return 'hidden';
+	}
+	
+	// Check for CloudFlare IP
+	if ( ! empty( $_SERVER['HTTP_CF_CONNECTING_IP'] ) ) {
+		return sanitize_text_field( $_SERVER['HTTP_CF_CONNECTING_IP'] );
+	}
+	
+	// Check for proxy
+	if ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+		$ips = explode( ',', $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		return sanitize_text_field( trim( $ips[0] ) );
+	}
+	
+	// Standard IP
+	if ( ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+		return sanitize_text_field( $_SERVER['REMOTE_ADDR'] );
+	}
+	
+	return 'unknown';
+}
+
+/**
+ * Security audit log
+ * 
+ * @param string $event_type
+ * @param array $data
+ * @return void
+ */
+function woocommerce_nfe_security_log( $event_type, $data = array() ) {
+	if ( ! apply_filters( 'woocommerce_nfe_enable_security_logging', false ) ) {
+		return;
+	}
+	
+	$log_entry = array(
+		'timestamp' => current_time( 'mysql' ),
+		'event' => sanitize_text_field( $event_type ),
+		'user_id' => get_current_user_id(),
+		'data' => array_map( 'sanitize_text_field', $data )
+	);
+	
+	// Don't log sensitive data
+	if ( WOOCOMMERCE_NFE_LOG_SENSITIVE_DATA === false ) {
+		unset( $log_entry['data']['password'] );
+		unset( $log_entry['data']['token'] );
+		unset( $log_entry['data']['secret'] );
+		unset( $log_entry['data']['api_key'] );
+	}
+	
+	// Log to file
+	$upload_dir = wp_upload_dir();
+	$log_dir = $upload_dir['basedir'] . '/woocommerce-nfe-logs/';
+	
+	if ( ! is_dir( $log_dir ) ) {
+		wp_mkdir_p( $log_dir );
+		
+		// Create .htaccess to protect log files
+		$htaccess_content = "Order Deny,Allow\nDeny from all";
+		@file_put_contents( $log_dir . '.htaccess', $htaccess_content );
+	}
+	
+	$log_file = $log_dir . 'security-' . date( 'Y-m-d' ) . '.log';
+	$log_message = date( 'Y-m-d H:i:s' ) . ' - ' . wp_json_encode( $log_entry ) . PHP_EOL;
+	
+	@file_put_contents( $log_file, $log_message, FILE_APPEND | LOCK_EX );
+}

--- a/templates/page-reports.php
+++ b/templates/page-reports.php
@@ -2,6 +2,11 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
+
+// Security: Verify user capabilities
+if ( ! current_user_can( 'manage_woocommerce' ) ) {
+	wp_die( __( 'Você não tem permissão para acessar esta página.', 'woocommerce' ) );
+}
 ?>
 <style>
 .page-title{
@@ -126,12 +131,12 @@ a.order-action:hover{
         $order = wc_get_order($key);
 
         echo '<tr>
-            <td scope="row">#'.$key.'</td>
-            <td>'.$info["datetime"].'</td>
-            <td>'.$info["error"].'</td>
+            <td scope="row">#'.esc_html( (string) $key ).'</td>
+            <td>'.esc_html( (string) $info["datetime"] ).'</td>
+            <td>'.wp_kses_post( (string) $info["error"] ).'</td>
             <td>
-              <a href="'.$edit_link.'"  target="_blank" class="order-action view-order">Visualizar Pedido</a>
-              <button type="button" class="order-action ignore-order" data-order-id="'.$key.'">Ignorar Pedido</button>
+              <a href="'.esc_url( $edit_link ).'"  target="_blank" class="order-action view-order">Visualizar Pedido</a>
+              <button type="button" class="order-action ignore-order" data-order-id="'.esc_attr( (string) $key ).'">Ignorar Pedido</button>
             </td>
           </tr>';
 
@@ -147,7 +152,10 @@ a.order-action:hover{
 </div>
 
 
-<?php $ajax_nonce = wp_create_nonce( 'G7EZCEv3tA' ); ?>
+<?php 
+// Security: Generate proper nonce with unique action
+$ajax_nonce = wp_create_nonce( 'wmbr_remove_order_invoice_nonce_' . get_current_user_id() ); 
+?>
 <script>
 
 jQuery(document).ready(function($){
@@ -166,19 +174,23 @@ jQuery(document).ready(function($){
       $.ajax({
         method: 'POST',
         url: ajaxurl,
+        dataType: 'json',
         data:{
           action: 'wmbr_remove_order_id_auto_invoice',
-          sec_nonce: '<?php echo $ajax_nonce; ?>',
-          order_id : order_id,
+          sec_nonce: '<?php echo esc_js($ajax_nonce); ?>',
+          order_id : parseInt(order_id, 10),
         }
       }).done(function(response){
-        result = $.parseJSON(response);
-        if(typeof result.success != 'undefined'){
+        if(response && typeof response.success != 'undefined'){
           self.parents('td').append('<p class="ignore-order-response">Pedido ignorado</p>');
           self.parents('td').find('button, a').remove();
         }else{
-          self.html(original_content);
+          self.html(original_content).removeClass('disabled');
+          alert('Erro ao processar solicitação');
         }
+      }).fail(function(){
+        self.html(original_content).removeClass('disabled');
+        alert('Erro na comunicação com o servidor');
       });
     }
   });

--- a/templates/payment-setting.php
+++ b/templates/payment-setting.php
@@ -41,9 +41,9 @@ Observação: A descrição do pagamento é obrigatória para o método de pagam
 	  ?>
 
 	    <div class="entry" style="margin-top:0">
-	    	<div><h4 style="display:inline-block;min-width:250px"><?php echo $gateway->method_title; ?></h4></div>
-	    	<div><?php echo $this->get_payment_methods_select($gateway->id); ?></div>
-				<div><?php echo $this->get_payment_desc_input($gateway->id); ?></div>
+	    	<div><h4 style="display:inline-block;min-width:250px"><?php echo esc_html( $gateway->method_title ); ?></h4></div>
+	    	<div><?php echo $this->get_payment_methods_select( $gateway->id ); ?></div>
+				<div><?php echo $this->get_payment_desc_input( $gateway->id ); ?></div>
 	    </div>
 	  <?php endforeach; ?>
 

--- a/woocommerce_nfe.php
+++ b/woocommerce_nfe.php
@@ -6,7 +6,7 @@
 * Description: Emissão de Nota Fiscal Eletrônica para WooCommerce através da REST API da Webmania®.
 * Author: WebmaniaBR
 * Author URI: https://webmaniabr.com
-* Version: 3.4.0.3
+* Version: 3.4.4
 * Copyright: © 2009-2024 Webmania.
 * License: GNU General Public License v3.0
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
@@ -14,6 +14,11 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
+}
+
+// Load security configuration
+if ( file_exists( __DIR__ . '/security-config.php' ) ) {
+	require_once __DIR__ . '/security-config.php';
 }
 
 // Declare compatibility for WooCommerce HPOS


### PR DESCRIPTION
## Goal

Bring the public repository **in line with the private/official master (3.4.4)**. The public tree was a much older lineage (3.4.0.3) that never received the security-hardening generation already shipped privately. After this PR the plugin tree is **byte-for-byte identical to the private master**.

Originally opened as the PHP 8 `abs()` fix for #25; expanded to the full sync at the maintainer's request (the abs() fix is included).

## What changes

**Security hardening (the bulk of the diff)**
- **TLS:** SSL verification enabled in the API SDKs — `CURLOPT_SSL_VERIFYPEER => true`, `CURLOPT_SSL_VERIFYHOST => 2` (was `false`/`false`) in `inc/sdk/NFe.php` and `inc/sdk/NFSe.php`.
- **Leaked credentials removed:** Correios API key/secret moved out of `assets/js/scripts.js` into PHP config (were hardcoded in the shipped JS).
- **Request integrity / output safety:** nonce verification, `sanitize_text_field` on inputs, and `esc_html` / `wp_kses` output escaping across checkout, admin, and print flows (`class-frontend.php`, `class-backend.php`, `assets/js/admin_scripts.js`).
- **Print/SSRF:** path-traversal and SSRF guards, WebmaniaBR-domain allowlist, and a response size limit in `class-print.php`.
- **New dedicated security module:** `inc/class-security.php` + `security-config.php`.
- **Safe client IP resolution:** `get_user_ip()` helper replacing raw `$_SERVER['CF-Connecting-IP']` reads.

**PHP 8 compatibility**
- Typed properties in `init-class.php`.
- Fix for the `abs()` / `number_format()` `TypeError` on non-numeric fee `line_total` (issue #25). `line_total` is normalized to float **once** at the top of the `get_fees()` loop and reused in both branches, so no raw string reaches any arithmetic or `number_format()` call (closes the else-branch path flagged in review).

**Version**
- Bumped `3.4.0.3` → `3.4.4` (`woocommerce_nfe.php` header + `init-class.php`).

## Notes

- The plugin source is now identical to the private master; the only intentionally-preserved public-only file is `.gitattributes` (line-ending normalization for this repo).
- Line endings in the committed blobs follow this repo's `.gitattributes` (`* text=auto`); file **content** matches the private master exactly.

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)